### PR TITLE
workaround editor usage

### DIFF
--- a/lib/editor.js
+++ b/lib/editor.js
@@ -16,8 +16,23 @@ module.exports.editMessage = async function editMessage (message, tempFileName) 
     openArgs.app = 'code'
   }
 
-  await open(fileTmp, openArgs)
+  await rageOpen(fileTmp, openArgs)
   const editedMessage = await readFile(fileTmp, 'utf8')
   fs.unlink(fileTmp, () => {}) // delete and forget
   return editedMessage
+}
+
+function rageOpen (fileTmp, openArgs) {
+  let alreadyResolved = false
+  return new Promise(resolve => {
+    const exit = () => {
+      if (!alreadyResolved) {
+        alreadyResolved = true
+        resolve()
+      }
+    }
+
+    process.once('SIGINT', exit)
+    open(fileTmp, openArgs).then(exit, exit)
+  })
 }


### PR DESCRIPTION
I'm opening this PR as a temporary, quick (and not very nice) solution for issue #21 

With this hotfix the user can edit the file and, if the closing of the editor is not recognized, a `SIGINT` in the console let continue the workflow and build the github release.

To fix this issue in a nicer way, I need more time. Meanwhile, users can benefit this workaround.

Let me know if it is worth or not