### PR TITLE
Fix wait editor

### DIFF
--- a/lib/editor.js
+++ b/lib/editor.js
@@ -33,10 +33,10 @@ function waitEditor (fileTmp) {
     subProcess.on('exit', (code) => {
       if (code === 0) {
         resolve()
+      } else {
+        reject(new Error(`Editor exit with code ${code}`))
       }
     })
-    subProcess.on('error', (e) => {
-      reject(e)
-    })
+    subProcess.on('error', reject)
   })
 }

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -2,22 +2,41 @@
 
 const fs = require('fs')
 const { promisify } = require('util')
-const open = require('open')
+const open = require('open-editor')
 const tempWrite = require('temp-write')
+const { spawn } = require('child_process')
 
 const readFile = promisify(fs.readFile)
 
 module.exports.editMessage = async function editMessage (message, tempFileName) {
   const fileTmp = await tempWrite(message, tempFileName)
 
-  const openArgs = { wait: true }
-  if (process.platform === 'win32') {
-    // TODO editor recognition: needed beacuse wait won't work without specifing an application
-    openArgs.app = 'code'
-  }
-
-  await open(fileTmp, openArgs)
+  await waitEditor(fileTmp)
   const editedMessage = await readFile(fileTmp, 'utf8')
   fs.unlink(fileTmp, () => {}) // delete and forget
   return editedMessage
+}
+
+function waitEditor (fileTmp) {
+  return new Promise((resolve, reject) => {
+    const editor = open.make([fileTmp])
+
+    // TODO should be customized for editors
+    editor.arguments.unshift('--wait')
+
+    const subProcess = spawn(editor.binary, editor.arguments, {
+      detached: true,
+      stdio: editor.isTerminalEditor ? 'inherit' : 'ignore',
+      shell: process.platform === 'win32'
+    })
+
+    subProcess.on('exit', (code) => {
+      if (code === 0) {
+        resolve()
+      }
+    })
+    subProcess.on('error', (e) => {
+      reject(e)
+    })
+  })
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@octokit/rest": "^16.24.1",
     "ajv": "^6.10.0",
     "commist": "^1.1.0",
-    "open": "^6.2.0",
+    "open-editor": "^2.0.1",
     "parse-github-url": "^1.0.2",
     "pino": "^5.12.2",
     "pino-pretty": "^2.6.0",

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -310,6 +310,51 @@ test('publish a module minor editing the release message', async t => {
   })
 })
 
+test('editor error', t => {
+  t.plan(2)
+
+  const opts = buildOptions()
+  opts.semver = 'minor'
+  opts.ghToken = '0000000000000000000000000000000000000000'
+  opts.ghReleaseEdit = true
+  delete opts.tag
+
+  const fakeFile = 'fake-temp'
+
+  const cmd = h.buildProxyCommand('../lib/commands/publish', {
+    npm: {
+      ping: { code: 0, data: 'Ping success: {}' },
+      config: { code: 0, data: 'my-registry' },
+      whoami: { code: 0, data: 'John Doo' },
+      publish: { code: 0 }
+    },
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 2 } } }),
+      '../editor': proxyquire('../lib/editor', {
+        'temp-write': async (message, filename) => fakeFile,
+        'open-editor': {
+          make: (tmpFile) => {
+            t.equals(tmpFile.pop(), fakeFile)
+            return { arguments: [] }
+          }
+        },
+        child_process: {
+          spawn: () => {
+            const e = new EventEmitter()
+            setImmediate(() => { e.emit('exit', 1) })
+            return e
+          }
+        },
+        fs: {
+          readFile () { t.fail('The file has not been edited') }
+        }
+      })
+    }
+  })
+
+  t.rejects(() => cmd(opts), new Error('Something went wrong creating the relase on GitHub.'))
+})
+
 test('publish a module from a branch that is not master', async t => {
   t.plan(2)
 

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -278,6 +278,7 @@ test('publish a module minor editing the release message', async t => {
         'open-editor': {
           make: (tmpFile) => {
             t.equals(tmpFile.pop(), fakeFile)
+            return { arguments: [] }
           }
         },
         child_process: {


### PR DESCRIPTION
Closes #21 

Waiting to add these feature in the external module, we could manage by ourself the waiting child process.

Didn't check if `--wait` works for all the editors, but the commons ones it is ok:
- [vscode](https://code.visualstudio.com/docs/editor/command-line)
- [atom](https://help.github.com/en/articles/associating-text-editors-with-git)
- [sublime text](https://help.github.com/en/articles/associating-text-editors-with-git)

@mcollina For vim should I use `--remote-wait`?

We could manage the error in order to create anyway the github release and then suggest to edit it in the github website.