### PR TITLE
command config

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,33 @@ releasify draft --from-commit 93c914beb07eede9635d1234c20cff0e41f093a1 --to-comm
 ```
 
 
+### ⚙ Config
+
+Save your default settings to speed up even more your release!
+Whan you run this command a prompt will ask you the value to store for the `arg` setting.
+The values are saved in an encrypted file, so it is human-unreadable.
+
+```sh
+releasify config [--arg <string>]          ➡ The argument to save
+                 [--verbose|-v <level>]    ➡ Print out more info. The value must be [debug, info, warn, error]
+                 [--help|-h]               ➡ Show this help message
+```
+
+#### Examples
+
+Save your github token (then digit it in the prompt):
+
+```sh
+releasify config --arg gh-token
+```
+---
+
+Save the default logging and print out where the store file is saved:
+
+```sh
+releasify config --arg verbose -v info
+```
+
 ## License
 
 Licensed under [MIT](./LICENSE).

--- a/lib/args.js
+++ b/lib/args.js
@@ -5,28 +5,33 @@ const LocalConf = require('./local-conf')
 
 // TODO --skip-label (don't download the labels from github)
 
+const argsNames = {
+  string: ['path',
+    'tag',
+    'verbose',
+    'semver',
+    'remote',
+    'branch',
+    'from-commit',
+    'to-commit',
+    'npm-access',
+    'npm-dist-tag',
+    'npm-otp',
+    'gh-token',
+    'gh-release-draft',
+    'gh-release-prerelease',
+    'arg'],
+  boolean: ['help',
+    'major',
+    'dry-run',
+    'no-verify',
+    'gh-release-edit']
+}
+
 module.exports = function parsedArgs (args) {
   const parsedArgs = argv(args, {
-    string: ['path',
-      'tag',
-      'verbose',
-      'semver',
-      'remote',
-      'branch',
-      'from-commit',
-      'to-commit',
-      'npm-access',
-      'npm-dist-tag',
-      'npm-otp',
-      'gh-token',
-      'gh-release-draft',
-      'gh-release-prerelease',
-      'arg'],
-    boolean: ['help',
-      'major',
-      'dry-run',
-      'no-verify',
-      'gh-release-edit'],
+    string: argsNames.string,
+    boolean: argsNames.boolean,
     alias: {
       help: ['h'],
       path: ['p'],
@@ -89,3 +94,5 @@ module.exports = function parsedArgs (args) {
     major: parsedArgs.major
   })
 }
+
+module.exports.argsNames = argsNames

--- a/lib/args.js
+++ b/lib/args.js
@@ -19,7 +19,9 @@ module.exports = function parsedArgs (args) {
       'npm-otp',
       'gh-token',
       'gh-release-draft',
-      'gh-release-prerelease'],
+      'gh-release-prerelease',
+      'arg',
+      'value'],
     boolean: ['help',
       'major',
       'dry-run',
@@ -63,6 +65,8 @@ module.exports = function parsedArgs (args) {
   // remove the aliases this way
   return Object.assign({}, {
     _: parsedArgs._,
+    arg: parsedArgs.arg,
+    value: parsedArgs.value,
     help: parsedArgs.help,
     path: parsedArgs.path,
     remote: parsedArgs.remote,

--- a/lib/args.js
+++ b/lib/args.js
@@ -20,8 +20,7 @@ module.exports = function parsedArgs (args) {
       'gh-token',
       'gh-release-draft',
       'gh-release-prerelease',
-      'arg',
-      'value'],
+      'arg'],
     boolean: ['help',
       'major',
       'dry-run',
@@ -66,7 +65,6 @@ module.exports = function parsedArgs (args) {
   return Object.assign({}, {
     _: parsedArgs._,
     arg: parsedArgs.arg,
-    value: parsedArgs.value,
     help: parsedArgs.help,
     path: parsedArgs.path,
     remote: parsedArgs.remote,

--- a/lib/args.js
+++ b/lib/args.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const argv = require('yargs-parser')
+const LocalConf = require('./local-conf')
 
 // TODO --skip-label (don't download the labels from github)
 
@@ -61,8 +62,10 @@ module.exports = function parsedArgs (args) {
 
   const ghToken = process.env[parsedArgs['gh-token']] || parsedArgs['gh-token']
 
+  const config = LocalConf()
+
   // remove the aliases this way
-  return Object.assign({}, {
+  return Object.assign({}, config.store, {
     _: parsedArgs._,
     arg: parsedArgs.arg,
     help: parsedArgs.help,

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,7 +6,7 @@ const commist = require('commist')()
 const { needToShowHelp } = require('./man')
 const parseArgs = require('./args');
 
-['help', 'login', 'whoami', 'publish', 'draft'].forEach(command => {
+['help', 'config', 'publish', 'draft'].forEach(command => {
   const fn = require(`./commands/${command}`)
   commist.register(command, async (args) => {
     const opts = parseArgs(args)

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const Conf = require('conf')
+
+module.exports = async function (args) {
+  // TODO
+  const config = new Conf({
+    configName: 'releasify',
+    projectName: 'releasify',
+    encryptionKey: 'fastify-team-is-awesome'
+  })
+  config.set('gh-token', 'A TOKEN')
+  console.log(config.path)
+}

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -7,13 +7,12 @@ const { validate } = require('../validation')
 
 const ARGS_SCHEMA = {
   type: 'object',
-  required: ['arg'],
+  required: ['flag'],
   properties: {
-    arg: {
+    flag: {
       type: 'string'
       // enum: [ 'debug', 'info', 'warn', 'error' ] // TODO
-    },
-    value: { type: 'string' }
+    }
   }
 }
 
@@ -28,13 +27,8 @@ module.exports = async function (args) {
     encryptionKey: 'fastify-team-is-awesome'
   })
 
-  let value = args.value
-  if (!args.value) {
-    const prompt = new Input({
-      message: `What is the value for ${args.arg}?`
-    })
-    value = await prompt.run()
-  }
+  const prompt = new Input({ message: `What is the value for ${args.arg}?` })
+  const value = await prompt.run()
   config.set(args.arg, value)
   logger.info('Saved %s to %s', args.arg, config.path)
 }

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -3,6 +3,7 @@
 const pino = require('pino')
 const { Input } = require('enquirer')
 const { validate } = require('../validation')
+const { argsNames } = require('../args')
 const LocalConf = require('../local-conf')
 
 const ARGS_SCHEMA = {
@@ -10,8 +11,8 @@ const ARGS_SCHEMA = {
   required: ['arg'],
   properties: {
     arg: {
-      type: 'string'
-      // enum: [ 'debug', 'info', 'warn', 'error' ] // TODO
+      type: 'string',
+      enum: argsNames.string.concat(argsNames.boolean)
     },
     verbose: {
       type: 'string',

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -25,4 +25,5 @@ module.exports = async function (args) {
   const value = await prompt.run()
   config.set(args.arg, value)
   logger.info('Saved %s to %s', args.arg, config.path)
+  return config.path
 }

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -1,14 +1,40 @@
 'use strict'
 
 const Conf = require('conf')
+const pino = require('pino')
+const { Input } = require('enquirer')
+const { validate } = require('../validation')
+
+const ARGS_SCHEMA = {
+  type: 'object',
+  required: ['arg'],
+  properties: {
+    arg: {
+      type: 'string'
+      // enum: [ 'debug', 'info', 'warn', 'error' ] // TODO
+    },
+    value: { type: 'string' }
+  }
+}
 
 module.exports = async function (args) {
-  // TODO
+  validate(args, ARGS_SCHEMA)
+
+  const logger = pino({ level: args.verbose, prettyPrint: true, base: null })
+
   const config = new Conf({
     configName: 'releasify',
     projectName: 'releasify',
     encryptionKey: 'fastify-team-is-awesome'
   })
-  config.set('gh-token', 'A TOKEN')
-  console.log(config.path)
+
+  let value = args.value
+  if (!args.value) {
+    const prompt = new Input({
+      message: `What is the value for ${args.arg}?`
+    })
+    value = await prompt.run()
+  }
+  config.set(args.arg, value)
+  logger.info('Saved %s to %s', args.arg, config.path)
 }

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -12,6 +12,10 @@ const ARGS_SCHEMA = {
     arg: {
       type: 'string'
       // enum: [ 'debug', 'info', 'warn', 'error' ] // TODO
+    },
+    verbose: {
+      type: 'string',
+      enum: [ 'debug', 'info', 'warn', 'error' ]
     }
   }
 }
@@ -21,9 +25,14 @@ module.exports = async function (args) {
 
   const logger = pino({ level: args.verbose, prettyPrint: true, base: null })
   const config = LocalConf()
-  const prompt = new Input({ message: `What is the value for ${args.arg}?` })
+  const { arg } = args
+  const prompt = new Input({ message: `What is the value for ${arg}?` })
   const value = await prompt.run()
-  config.set(args.arg, value)
-  logger.info('Saved %s to %s', args.arg, config.path)
-  return config.path
+  config.set(arg, value)
+  logger.info('Saved %s to %s', arg, config.path)
+
+  return {
+    arg,
+    path: config.path
+  }
 }

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -1,15 +1,15 @@
 'use strict'
 
-const Conf = require('conf')
 const pino = require('pino')
 const { Input } = require('enquirer')
 const { validate } = require('../validation')
+const LocalConf = require('../local-conf')
 
 const ARGS_SCHEMA = {
   type: 'object',
-  required: ['flag'],
+  required: ['arg'],
   properties: {
-    flag: {
+    arg: {
       type: 'string'
       // enum: [ 'debug', 'info', 'warn', 'error' ] // TODO
     }
@@ -20,13 +20,7 @@ module.exports = async function (args) {
   validate(args, ARGS_SCHEMA)
 
   const logger = pino({ level: args.verbose, prettyPrint: true, base: null })
-
-  const config = new Conf({
-    configName: 'releasify',
-    projectName: 'releasify',
-    encryptionKey: 'fastify-team-is-awesome'
-  })
-
+  const config = LocalConf()
   const prompt = new Input({ message: `What is the value for ${args.arg}?` })
   const value = await prompt.run()
   config.set(args.arg, value)

--- a/lib/commands/login.js
+++ b/lib/commands/login.js
@@ -1,5 +1,0 @@
-'use strict'
-
-module.exports = async function (args) {
-  // TODO
-}

--- a/lib/commands/whoami.js
+++ b/lib/commands/whoami.js
@@ -1,5 +1,0 @@
-'use strict'
-
-module.exports = async function (args) {
-  // TODO
-}

--- a/lib/local-conf.js
+++ b/lib/local-conf.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const Conf = require('conf')
+
+const confSettings = {
+  configName: 'releasify',
+  projectName: 'releasify',
+  encryptionKey: 'fastify-team-is-awesome'
+}
+
+module.exports = function localConfig () {
+  return new Conf(confSettings)
+}

--- a/man/config
+++ b/man/config
@@ -1,8 +1,11 @@
-Usage: releasify config [--arg <string>] [--help|-h]
+Usage: releasify config [--arg <string>] [--verbose|-v <level>] [--help|-h]
   store your default arguments' values to a human-unreadable file
 
   --arg <string>
       The argument name or alias to save
+
+  -v, --verbose <level>
+      Print out more info. The value must be [debug, info, warn, error]
 
   -h, --help
       Show this help message

--- a/man/config
+++ b/man/config
@@ -1,11 +1,8 @@
-Usage: releasify draft [--arg <string>] [--value <string>] [--help|-h]
-  store your args to a file
+Usage: releasify config [--arg <string>] [--help|-h]
+  store your default arguments' values to a human-unreadable file
 
   --arg <string>
-      The arg name or alias where save the default value
-
-  --value <string> [optional]
-      The default value to set. If not set the value must be typed
+      The argument name or alias to save
 
   -h, --help
       Show this help message

--- a/man/config
+++ b/man/config
@@ -1,0 +1,11 @@
+Usage: releasify draft [--arg|-a <string>] [--value <string>] [--help|-h]
+  store your args to a file
+
+  -a, --arg <string>
+      blabla
+
+  --value <string>
+      blabla
+
+  -h, --help
+      Show this help message

--- a/man/config
+++ b/man/config
@@ -1,11 +1,11 @@
-Usage: releasify draft [--arg|-a <string>] [--value <string>] [--help|-h]
+Usage: releasify draft [--arg <string>] [--value <string>] [--help|-h]
   store your args to a file
 
-  -a, --arg <string>
-      blabla
+  --arg <string>
+      The arg name or alias where save the default value
 
-  --value <string>
-      blabla
+  --value <string> [optional]
+      The default value to set. If not set the value must be typed
 
   -h, --help
       Show this help message

--- a/man/help
+++ b/man/help
@@ -4,7 +4,7 @@ Install via npm:
 Usage: releasify <command>
 
 where <command> is one of:
-  draft, publish
+  draft, publish, config
 
 releasify <command> -h 
   quick help on <command>

--- a/man/login
+++ b/man/login
@@ -1,1 +1,0 @@
-todo man login

--- a/man/whoami
+++ b/man/whoami
@@ -1,1 +1,0 @@
-todo man whoami

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "ajv": "^6.10.0",
     "commist": "^1.1.0",
     "conf": "^4.1.0",
+    "enquirer": "^2.3.1",
     "open-editor": "^2.0.1",
     "parse-github-url": "^1.0.2",
     "pino": "^5.12.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@octokit/rest": "^16.24.1",
     "ajv": "^6.10.0",
     "commist": "^1.1.0",
+    "conf": "^4.1.0",
     "open-editor": "^2.0.1",
     "parse-github-url": "^1.0.2",
     "pino": "^5.12.2",

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -8,6 +8,7 @@ test('parse all args', t => {
   t.plan(1)
 
   const argv = [
+    '--arg', 'arg',
     '--help', 'true',
     '--path', 'a/path',
     '--tag', 'vPattern',
@@ -33,6 +34,7 @@ test('parse all args', t => {
   t.strictDeepEqual(parsedArgs, {
     _: [],
     help: true,
+    arg: 'arg',
     path: 'a/path',
     tag: 'vPattern',
     verbose: 'info',
@@ -61,6 +63,7 @@ test('check default values', t => {
   t.strictDeepEqual(parsedArgs, {
     _: [],
     help: false,
+    arg: undefined,
     path: process.cwd(),
     tag: undefined,
     verbose: 'warn',
@@ -87,6 +90,7 @@ test('parse args with = assignment', t => {
 
   const argv = [
     '--help=false',
+    '--arg=arg',
     '--path="a/path with space"',
     '--tag=vPattern',
     '--verbose=info',
@@ -111,6 +115,7 @@ test('parse args with = assignment', t => {
   t.strictDeepEqual(parsedArgs, {
     _: [],
     help: false,
+    arg: 'arg',
     path: 'a/path with space',
     tag: 'vPattern',
     verbose: 'info',
@@ -154,6 +159,7 @@ test('parse args aliases', t => {
   t.strictDeepEqual(parsedArgs, {
     _: [],
     help: true,
+    arg: undefined,
     path: 'a/path',
     tag: 'vPattern',
     verbose: 'info',

--- a/test/command-config.test.js
+++ b/test/command-config.test.js
@@ -19,7 +19,7 @@ function buildOptions () {
 test('mandatory options', t => {
   t.plan(2)
   t.rejects(() => cmd({}), new Error("should have required property 'arg'"))
-  t.rejects(() => cmd(buildOptions()), new Error('.verbose should be equal to one of the allowed values'))
+  t.rejects(() => cmd(buildOptions()), new Error('.arg should be equal to one of the allowed values, .verbose should be equal to one of the allowed values'))
 })
 
 test('save config data', async t => {

--- a/test/command-config.test.js
+++ b/test/command-config.test.js
@@ -43,7 +43,7 @@ test('save config data', async t => {
 
   const build = await cmd(opts)
   t.equals(build.arg, opts.arg)
-  t.match(build.path.toLowerCase(), /releasify-nodejs\\config\\releasify.json$/)
+  t.match(build.path.toLowerCase(), /releasify-nodejs[/\\].*releasify.json$/)
 
   t.test('correct value saved', t => {
     const localConf = LocalConf()

--- a/test/command-config.test.js
+++ b/test/command-config.test.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const t = require('tap')
+const h = require('./helper')
+
+const cmd = h.buildProxyCommand('../lib/commands/config')
+const LocalConf = require('../lib/local-conf')
+
+const { test } = t
+
+function buildOptions () {
+  const options = {
+    arg: 'invalid',
+    verbose: 'invalid'
+  }
+  return Object.assign({}, options)
+}
+
+test('mandatory options', t => {
+  t.plan(2)
+  t.rejects(() => cmd({}), new Error("should have required property 'arg'"))
+  t.rejects(() => cmd(buildOptions()), new Error('.verbose should be equal to one of the allowed values'))
+})
+
+test('save config data', async t => {
+  t.plan(3)
+
+  const opts = buildOptions()
+  opts.arg = 'semver'
+  opts.verbose = 'error'
+
+  const inputValue = 'fake input string'
+
+  const cmd = h.buildProxyCommand('../lib/commands/config', { external:
+    {
+      enquirer: {
+        Input: function () {
+          return { async run () { return inputValue } }
+        }
+      }
+    }
+  })
+
+  const build = await cmd(opts)
+  t.equals(build.arg, opts.arg)
+  t.match(build.path.toLowerCase(), /releasify-nodejs\\config\\releasify.json$/)
+
+  t.test('correct value saved', t => {
+    const localConf = LocalConf()
+    t.plan(1)
+    t.equals(localConf.get('semver'), inputValue)
+  })
+})

--- a/test/show-man.test.js
+++ b/test/show-man.test.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const h = require('./helper')
 
 // TODO move this array
-const commands = ['help', 'login', 'whoami', 'publish', 'draft']
+const commands = ['help', 'config', 'publish', 'draft']
 
 test('show help messages', async t => {
   t.plan(1 + commands.length)


### PR DESCRIPTION
This PR will close #23 and #3 
Relates to #2 

Starting to design how to store the common config.
The idea is to introduce a config command that consent to users to store the key/value pair they use often and then load those settings when the other commands will execute.

Another aspect is to lock some keys, like `--major` and `--npm-otp`.

The config will be stored in `~/releasify` directory and not in clear text

Let me know your considerations 👍