### PR TITLE
Fix #25: Set toCommit to HEAD when not specified as arg

### DIFF
--- a/lib/commands/draft.js
+++ b/lib/commands/draft.js
@@ -43,7 +43,7 @@ module.exports = async function (args) {
     const tagPattern = args.tag || `v${releaseBuilder.getCurrentVersionInfo().major}\\.[0-9]*\\.[0-9]*`
     logger.debug('Searching for tag pattern %s', tagPattern)
 
-    toCommit = await git.getLastTagCommit(tagPattern)
+    toCommit = await git.getLastTagCommit(tagPattern || 'HEAD')
   }
   const commits = await git.getLogs(args.fromCommit, toCommit)
   logger.debug('Found %d commits from %s to %s', commits.length, args.fromCommit, toCommit)


### PR DESCRIPTION
Fix #25: Set toCommit to HEAD when not specified as arg and repo doesn't has any tag already created.


