### PR TITLE
changelog titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ releasify publish [--path|-p <path>]             ➡ The path to the project to 
                   [--gh-release-edit|-e]         ➡ Open an editor to modify the release message before creating it on GitHub
                   [--gh-release-draft]           ➡ Create the GitHub Release as draft. Default `false`
                   [--gh-release-prerelease]      ➡ Create the GitHub Release as pre-release. Default `false`
-                  [--npm-access|-a <string>]     ➡ It will set the --access flag of `npm publish` command. Useful for scoped modules. The value must be [public, restricted]
-                  [--npm-dist-tag <string>]      ➡ It will add a npm tag to the module, like `beta` or `next`
-                  [--npm-otp <code>]             ➡ It will provide the otp code to the npm publish
-                  [--major|-m]                   ➡ It will unlock the release of a major release
-                  [--help|-h]                    ➡ Show this help message
+                  [--gh-group-by-label|-l <label>] ➡ Group the commits in the changelog message by PR's labels
+                  [--npm-access|-a <string>]       ➡ It will set the --access flag of `npm publish` command. Useful for scoped modules. The value must be [public, restricted]
+                  [--npm-dist-tag <string>]        ➡ It will add a npm tag to the module, like `beta` or `next`
+                  [--npm-otp <code>]               ➡ It will provide the otp code to the npm publish
+                  [--major|-m]                     ➡ It will unlock the release of a major release
+                  [--help|-h]                      ➡ Show this help message
 ```
 
 #### Examples
@@ -88,6 +89,29 @@ Explanation:
 + `-b`: it will check that your local repository is in the right branch and it will be used in the bump phase
 + `-t`: it will be used to explore the git history to find the commit messages. This is necessary when your tag name pattern doesn't follow the `v<semver-version>` pattern. By default the value of this parameter is `v${major version read from package.json}*`
 
+---
+
+The following example release a major version of `your-module` to NPM with a grouped GitHub release message.
+If a PR has many matching labels, it will be assigned to the first label in the command line.
+If a PR doesn't have any match with the label in the args, it will append at the end of the message.
+
+```sh
+cd /your-module
+releasify publish -v debug -m -s major -l feature -l bugfix -l documentation
+
+# example message:
+**feature**:
+- four this is feature (#4)
+
+
+**bugfix**:
+- two this is a bugfix (#2)
+- three this is a doc bugfix (#3)
+
+
+**commit**:
+- five this is a typescript pr (#5)
+```
 
 ### ☄ Draft
 
@@ -108,6 +132,7 @@ releasify draft [--path|-p <path>]        ➡ The path to the project to draft. 
                 [--to-commit <hash>]      ➡ Specify a commit hash where to stop to generate the release message. The --tag arg will be ignored
                 [--semver|-s <release>]   ➡ Force the release type. The value must be [major, premajor, minor, preminor, patch, prepatch, prerelease]
                 [--verbose|-v <level>]    ➡ Print out more info. The value must be [debug, info, warn, error]
+                [--gh-group-by-label|-l <label>] ➡ Group the commits in the changelog message by PR's labels
                 [--help|-h]               ➡ Show this help message
 ```
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -21,6 +21,7 @@ const argsNames = {
     'gh-release-draft',
     'gh-release-prerelease',
     'arg'],
+  array: ['gh-group-by-label'],
   boolean: ['help',
     'major',
     'dry-run',
@@ -43,7 +44,8 @@ module.exports = function parsedArgs (args) {
     'gh-token': 'GITHUB_OAUTH_TOKEN',
     'gh-release-draft': false,
     'gh-release-prerelease': false,
-    'gh-release-edit': false
+    'gh-release-edit': false,
+    'gh-group-by-label': []
   }, config.store)
 
   const parsedArgs = argv(args, {
@@ -58,6 +60,7 @@ module.exports = function parsedArgs (args) {
       'npm-access': ['a'],
       'gh-token': ['k'],
       'gh-release-edit': ['e'],
+      'gh-group-by-label': ['l'],
       verbose: ['v'],
       semver: ['s'],
       major: ['m'],
@@ -87,6 +90,7 @@ module.exports = function parsedArgs (args) {
     ghReleaseEdit: parsedArgs['gh-release-edit'],
     ghReleaseDraft: parsedArgs['gh-release-draft'],
     ghReleasePrerelease: parsedArgs['gh-release-prerelease'],
+    ghGroupByLabel: parsedArgs['gh-group-by-label'],
     npmAccess: parsedArgs['npm-access'],
     npmDistTag: parsedArgs['npm-dist-tag'],
     npmOtp: parsedArgs['npm-otp'],

--- a/lib/commands/draft.js
+++ b/lib/commands/draft.js
@@ -34,7 +34,7 @@ module.exports = async function (args) {
   const git = GitDirectory(args.path)
 
   const pkg = git.getRepoPackage()
-  const releaseBuilder = ReleaseBuilder(pkg.name)
+  const releaseBuilder = ReleaseBuilder(pkg.name, { labels: args.ghGroupByLabel })
   releaseBuilder.setCurrentVersion(pkg.version)
   logger.debug('Found %s version: %s', releaseBuilder.getName(), releaseBuilder.getCurrentVersion())
 

--- a/lib/commands/draft.js
+++ b/lib/commands/draft.js
@@ -22,6 +22,12 @@ const ARGS_SCHEMA = {
     semver: {
       type: 'string',
       enum: [ 'major', 'premajor', 'minor', 'preminor', 'patch', 'prepatch', 'prerelease' ]
+    },
+    ghGroupByLabel: {
+      type: 'array',
+      items: {
+        type: 'string'
+      }
     }
   }
 }

--- a/lib/release-builder.js
+++ b/lib/release-builder.js
@@ -5,7 +5,7 @@ const semver = require('semver')
 module.exports = function releaseBuilder (moduleName, { labels }) {
   const groupLabels = labels
   const semverBuckets = {
-    list: []
+    commit: []
   }
 
   groupLabels.forEach(l => {
@@ -40,19 +40,14 @@ module.exports = function releaseBuilder (moduleName, { labels }) {
    */
   function addLine (message, labels = []) {
     if (labels.length) {
-      const addedTo = labels.reduce((adds, l) => {
-        if (semverBuckets[l]) {
-          semverBuckets[l].push(message)
-          return adds + 1
-        }
-      }, 0)
-
-      if (addedTo > 0) {
+      const bucket = groupLabels.find(gl => labels.includes(gl))
+      if (bucket) {
+        semverBuckets[bucket].push(message)
         return
       }
     }
 
-    semverBuckets.list.push(message)
+    semverBuckets.commit.push(message)
   }
 
   function suggestRelease () {
@@ -73,19 +68,23 @@ module.exports = function releaseBuilder (moduleName, { labels }) {
       version: newVersion,
       oldVersion: currentVersion,
       message: toString(),
-      lines: semverBuckets.list.length
+      lines: Object.values(semverBuckets).reduce((sum, bucket) => { return sum + bucket.length }, 0)
     }
   }
 
   function toString () {
     if (groupLabels.length) {
-      return groupLabels.reduce((out, label) => {
-        out += `${label}:\n${semverBuckets[label].reduceRight(listCommits, '')}\n\n`
-        return out
-      }, '')
+      return [...groupLabels, 'commit']
+        .reduce((out, label) => {
+          const commitList = semverBuckets[label].reduceRight(listCommits, '')
+          if (commitList) {
+            out += `**${label}**:\n${commitList}\n\n`
+          }
+          return out
+        }, '')
     }
 
-    return semverBuckets.list.reduceRight(listCommits, '📚 PR:\n')
+    return semverBuckets.commit.reduceRight(listCommits, '📚 PR:\n')
   }
 
   function listCommits (out, item) {

--- a/lib/release-builder.js
+++ b/lib/release-builder.js
@@ -2,10 +2,15 @@
 
 const semver = require('semver')
 
-module.exports = function releaseBuilder (moduleName) {
+module.exports = function releaseBuilder (moduleName, { labels }) {
+  const groupLabels = labels
   const semverBuckets = {
     list: []
   }
+
+  groupLabels.forEach(l => {
+    semverBuckets[l] = []
+  })
 
   const name = moduleName
   let currentVersion
@@ -34,6 +39,19 @@ module.exports = function releaseBuilder (moduleName) {
    * @param {Array} labels
    */
   function addLine (message, labels = []) {
+    if (labels.length) {
+      const addedTo = labels.reduce((adds, l) => {
+        if (semverBuckets[l]) {
+          semverBuckets[l].push(message)
+          return adds + 1
+        }
+      }, 0)
+
+      if (addedTo > 0) {
+        return
+      }
+    }
+
     semverBuckets.list.push(message)
   }
 
@@ -60,9 +78,18 @@ module.exports = function releaseBuilder (moduleName) {
   }
 
   function toString () {
-    return semverBuckets.list.reduceRight((out, item) => {
-      out += `- ${item}\n`
-      return out
-    }, '📚 PR:\n')
+    if (groupLabels.length) {
+      return groupLabels.reduce((out, label) => {
+        out += `${label}:\n${semverBuckets[label].reduceRight(listCommits, '')}\n\n`
+        return out
+      }, '')
+    }
+
+    return semverBuckets.list.reduceRight(listCommits, '📚 PR:\n')
+  }
+
+  function listCommits (out, item) {
+    out += `- ${item}\n`
+    return out
   }
 }

--- a/man/draft
+++ b/man/draft
@@ -19,5 +19,8 @@ Usage: releasify draft [--path|-p <path>] [--semver|-s <release>] [--tag|-t <pat
   -v, --verbose <level>
       Print out more info. The value must be [debug, info, warn, error]
 
+  -l, --gh-group-by-label <label>
+      Group the commits in the release message by PR's labels
+
   -h, --help
       Show this help message

--- a/man/publish
+++ b/man/publish
@@ -25,6 +25,9 @@ Usage: releasify publish [--path|-p <path>] [--tag|-t <pattern>] [--semver|-s <r
   -k, --gh-token <env name var | token>
       The GitHub OAUTH token. You can set it with an env var name or a valid token. Default env var `GITHUB_OAUTH_TOKEN`
 
+  -l, --gh-group-by-label <label1,label2>
+      Group the commits in the release message by PR's labels
+
   -e, --gh-release-edit
       Open an editor to modify the release message before creating it on GitHub
 

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -28,7 +28,9 @@ test('parse all args', t => {
     '--gh-token', 'MY_KEY',
     '--gh-release-edit', 'true',
     '--gh-release-draft', 'true',
-    '--gh-release-prerelease', 'true'
+    '--gh-release-prerelease', 'true',
+    '--gh-group-by-label', 'bugfix',
+    '--gh-group-by-label', 'docs'
   ]
   const parsedArgs = parseArgs(argv)
 
@@ -53,7 +55,8 @@ test('parse all args', t => {
     ghToken: 'MY_KEY',
     ghReleaseEdit: true,
     ghReleaseDraft: 'true',
-    ghReleasePrerelease: 'true'
+    ghReleasePrerelease: 'true',
+    ghGroupByLabel: ['bugfix', 'docs']
   })
 })
 
@@ -82,7 +85,8 @@ test('check default values', t => {
     ghToken: 'GITHUB_OAUTH_TOKEN',
     ghReleaseEdit: false,
     ghReleaseDraft: false,
-    ghReleasePrerelease: false
+    ghReleasePrerelease: false,
+    ghGroupByLabel: []
   })
 })
 
@@ -109,7 +113,9 @@ test('parse args with = assignment', t => {
     '--gh-token=MY_KEY',
     '--gh-release-edit=true',
     '--gh-release-draft=true',
-    '--gh-release-prerelease=true'
+    '--gh-release-prerelease=true',
+    '--gh-group-by-label=bugfix',
+    '--gh-group-by-label=docs'
   ]
   const parsedArgs = parseArgs(argv)
 
@@ -134,7 +140,8 @@ test('parse args with = assignment', t => {
     ghToken: 'MY_KEY',
     ghReleaseEdit: true,
     ghReleaseDraft: 'true',
-    ghReleasePrerelease: 'true'
+    ghReleasePrerelease: 'true',
+    ghGroupByLabel: ['bugfix', 'docs']
   })
 })
 
@@ -153,7 +160,9 @@ test('parse args aliases', t => {
     '-n',
     '-a', 'public',
     '-k', 'MY_KEY',
-    '-e'
+    '-e',
+    '-l', 'bugfix',
+    '-l', 'docs'
   ]
   const parsedArgs = parseArgs(argv)
 
@@ -178,7 +187,8 @@ test('parse args aliases', t => {
     ghToken: 'MY_KEY',
     ghReleaseEdit: true,
     ghReleaseDraft: false,
-    ghReleasePrerelease: false
+    ghReleasePrerelease: false,
+    ghGroupByLabel: ['bugfix', 'docs']
   })
 })
 

--- a/test/command-draft.test.js
+++ b/test/command-draft.test.js
@@ -161,7 +161,7 @@ test('group changelog message by labels', async t => {
 
   const cmd = h.buildProxyCommand('../lib/commands/draft', {
     git: {
-      tag: { history: 4 },
+      tag: { history: 5 },
       log: { messages: [
         'one this is a message without PR',
         'two this is a bugfix (#2)',
@@ -192,6 +192,7 @@ test('group changelog message by labels', async t => {
 
 
 **commit**:
+- one this is a message without PR
 - five this is a typescript pr (#5)
 
 
@@ -215,7 +216,7 @@ test('group changelog order', async t => {
 
   const cmd = h.buildProxyCommand('../lib/commands/draft', {
     git: {
-      tag: { history: 4 },
+      tag: { history: 5 },
       log: { messages: [
         'one this is a message without PR',
         'two this is a bugfix (#2)',
@@ -249,6 +250,7 @@ test('group changelog order', async t => {
 
 
 **commit**:
+- one this is a message without PR
 - five this is a typescript pr (#5)
 
 

--- a/test/command-draft.test.js
+++ b/test/command-draft.test.js
@@ -18,7 +18,8 @@ function buildOptions () {
     tag: null,
     verbose: 'error',
     fromCommit: 'HEAD',
-    semver: null
+    semver: null,
+    ghGroupByLabel: []
   }
   return Object.assign({}, options)
 }
@@ -141,4 +142,46 @@ test('error management getting PR: works but won\' apply labels', async t => {
   const build = await cmd(opts)
   t.equals(build.version, '11.14.42')
   t.equals(build.oldVersion, '11.14.42')
+})
+
+test('group changelog message by labels', async t => {
+  t.plan(1)
+
+  const prLabels = [
+    [{ name: 'bugfix' }], // #2
+    [{ name: 'bugfix' }, { name: 'documentation' }], // #3
+    [{ name: 'feature' }], // #4
+    [{ name: 'typescript' }] // #5
+  ]
+
+  const dataRulette = {}
+  Object.defineProperty(dataRulette, 'data', {
+    get: function () {
+      return prLabels.shift()
+    }
+  })
+
+  const cmd = h.buildProxyCommand('../lib/commands/draft', {
+    git: {
+      tag: { history: 4 },
+      log: { messages: [
+        'one this is a message without PR',
+        'two this is a bugfix (#2)',
+        'three this is a doc bugfix (#3)',
+        'four this is feature (#4)',
+        'five this is a typescript pr (#5)'
+      ] }
+    },
+    github: {
+      labels: dataRulette
+    }
+  })
+  const opts = buildOptions()
+  opts.path = join(__dirname, 'fake-project/')
+  opts.ghGroupByLabel = ['feature', 'bugfix', 'documentation']
+  delete opts.tag // autosense
+  delete opts.semver // auto-calculate
+
+  const build = await cmd(opts)
+  t.equals(build.message, 'ciao')
 })

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -25,7 +25,8 @@ function buildOptions () {
     remote: 'origin',
     branch: 'master',
     fromCommit: 'HEAD',
-    ghToken: 'INVALID_TOKEN'
+    ghToken: 'INVALID_TOKEN',
+    ghGroupByLabel: []
   }
   return Object.assign({}, options)
 }

--- a/test/proxy/octokit-proxy.js
+++ b/test/proxy/octokit-proxy.js
@@ -27,7 +27,7 @@ module.exports = function factory (opts = {}) {
 
           // customize the output labels
           let data
-          if (opts['labels'] && opts['labels'].data) {
+          if (opts['labels']) {
             data = opts['labels'].data
           } else {
             data = [{ name: 'documentation' }]

--- a/test/proxy/octokit-proxy.js
+++ b/test/proxy/octokit-proxy.js
@@ -24,6 +24,15 @@ module.exports = function factory (opts = {}) {
           if (shouldThrows(opts['labels'], options)) {
             throw new Error('HttpError - Fake limit reached')
           }
+
+          // customize the output labels
+          let data
+          if (opts['labels'] && opts['labels'].data) {
+            data = opts['labels'].data
+          } else {
+            data = [{ name: 'documentation' }]
+          }
+
           return {
             status: 200,
             url: `https://api.github.com/repos/${options.owner}/${options.repo}/issues/${options.number}/labels`,
@@ -31,7 +40,7 @@ module.exports = function factory (opts = {}) {
               server: 'Test.com',
               status: '200OK'
             },
-            data: [{ name: 'documentation' }],
+            data,
             pullRequest: {
               id: options.number
             }


### PR DESCRIPTION
Opening a not working PR 😄

The idea is to group the commits by the labels of the PRs, in the same order the users pass them as args.

What do you think for cases like:

- if a PR has multiple matching labels (like `doc` and `bugfix`)? - I think the input order always win, so it would be different running `releasify draft -l doc -l bugfix` and `releasify draft -l bugfix -l doc`
- if a PR doesn't have any matching labels (need to set append at the end)?

?
