### PR TITLE
fix gh-release-prerelease flag

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -18,15 +18,16 @@ const argsNames = {
     'npm-dist-tag',
     'npm-otp',
     'gh-token',
-    'gh-release-draft',
-    'gh-release-prerelease',
     'arg'],
   array: ['gh-group-by-label'],
   boolean: ['help',
     'major',
     'dry-run',
     'no-verify',
-    'gh-release-edit']
+    'gh-release-edit',
+    'gh-release-draft',
+    'gh-release-prerelease'
+  ]
 }
 
 module.exports = function parsedArgs (args) {

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -54,8 +54,8 @@ test('parse all args', t => {
     npmDistTag: 'next',
     ghToken: 'MY_KEY',
     ghReleaseEdit: true,
-    ghReleaseDraft: 'true',
-    ghReleasePrerelease: 'true',
+    ghReleaseDraft: true,
+    ghReleasePrerelease: true,
     ghGroupByLabel: ['bugfix', 'docs']
   })
 })
@@ -139,9 +139,33 @@ test('parse args with = assignment', t => {
     npmDistTag: 'next',
     ghToken: 'MY_KEY',
     ghReleaseEdit: true,
-    ghReleaseDraft: 'true',
-    ghReleasePrerelease: 'true',
+    ghReleaseDraft: true,
+    ghReleasePrerelease: true,
     ghGroupByLabel: ['bugfix', 'docs']
+  })
+})
+
+test('parse boolean args', t => {
+  t.plan(1)
+
+  const argv = [
+    '--help',
+    '--major',
+    '--dry-run',
+    '--no-verify',
+    '--gh-release-edit',
+    '--gh-release-draft',
+    '--gh-release-prerelease'
+  ]
+  const parsedArgs = parseArgs(argv)
+  t.like(parsedArgs, {
+    help: true,
+    major: true,
+    dryRun: true,
+    noVerify: true,
+    ghReleaseEdit: true,
+    ghReleaseDraft: true,
+    ghReleasePrerelease: true
   })
 })
 


### PR DESCRIPTION
Fixes #36 

The flags were used like string, so the parsing was inconsistent causing the Github handler throws an error:
https://octokit.github.io/rest.js/v16#api-Repos-createRelease