### PR TITLE
Fix #25: Set toCommit to HEAD when not specified as arg, and adding a unit test

### DIFF
--- a/lib/commands/draft.js
+++ b/lib/commands/draft.js
@@ -50,6 +50,7 @@ module.exports = async function (args) {
     logger.debug('Searching for tag pattern %s', tagPattern)
 
     toCommit = await git.getLastTagCommit(tagPattern)
+    if (!toCommit) { toCommit = 'HEAD' }
   }
   const commits = await git.getLogs(args.fromCommit, toCommit)
   logger.debug('Found %d commits from %s to %s', commits.length, args.fromCommit, toCommit)

--- a/test/command-draft.test.js
+++ b/test/command-draft.test.js
@@ -89,6 +89,36 @@ test('draft a range commit release message', async t => {
   await cmd(opts)
 })
 
+test('draft a range commit release message when toCommit not specified and no tags', async t => {
+  t.plan(1)
+
+  const opts = buildOptions()
+  opts.path = join(__dirname, 'fake-project/')
+  const commitHash = '123abc'.repeat(6)
+  opts.fromCommit = `${commitHash}4`
+  delete opts.toCommit
+  opts.tag = 'bad-pattern' // no tags
+  delete opts.semver // auto-calculate
+
+  const cmd = h.buildProxyCommand('../lib/commands/draft', {
+    git: {
+      tag: { history: 0 },
+      log: {
+        inputChecker (logArgs) {
+          t.strictDeepEqual(logArgs, {
+            from: opts.fromCommit,
+            to: 'HEAD'
+          })
+        }
+      }
+    },
+    github: { }, // default OK
+    npm: { } // default OK
+  })
+
+  await cmd(opts)
+})
+
 test('draft the first release', async t => {
   t.plan(3)
 


### PR DESCRIPTION
See issue #25 

I tried to understand business logic of "draft a range commit" and adding relative test in case no args --toCommit is specified and no tag is present on repository. Not sure about this is the correct implementation.

While running all the test unfortunately I've noticed one test is failed:

```
  test/args.test.js                        
  65 |   const parsedArgs = parseArgs([])  
  66 |                                     
> 67 |   t.strictDeepEqual(parsedArgs, {   
     | ----^                               
  68 |     _: [],                          
  69 |     help: false,                    
  70 |     arg: undefined,                 

  --- expected                      
  +++ actual                        
  @@ -19,6 +19,6 @@                 
     "npmOtp": undefined,           
     "tag": undefined,              
     "verbose": "warn",             
  -  "semver": undefined,           
  +  "semver": "fake input string", 
     "major": false,                
   }   
```
No idea why this test is failed.

#### Checklist

- [X] run `npm run test`
- [X] tests and/or benchmarks are included
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


I appreciate if you can add the "hacktoberfest" topic to this repository or adding the "hacktoberfest-accepted" label to the PR.
Thanks!
