### PR TITLE
fix(commands): misspelling of 'release' in error outputs

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -80,7 +80,7 @@ module.exports = async function (args) {
   logger.info('Ready to release %s: %s --> %s', releasing.release, releasing.oldVersion, releasing.version)
 
   if (releasing.lines === 0) {
-    throw new Error('There are ZERO commit to relase!')
+    throw new Error('There are ZERO commit to release!')
   }
 
   // TODO check the validity of the GH-TOKEN.. need another param with the github account:
@@ -166,7 +166,7 @@ Consider creating a release on GitHub by yourself with this message:\n${releasin
     logger.debug('Pulled new tags from remote: %s', args.remote)
   } catch (error) {
     logger.error(error)
-    const messageError = `Something went wrong creating the relase on GitHub.
+    const messageError = `Something went wrong creating the release on GitHub.
 The 'npm publish' and 'git push' has been done!
 Consider creating a release on GitHub by yourself with this message:\n${releasing.message}`
     throw new Error(messageError)

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -58,7 +58,7 @@ test('try to publish 0 new commits', t => {
   opts.semver = 'patch'
   opts.ghToken = '0000000000000000000000000000000000000000'
   delete opts.tag
-  t.rejects(() => cmd(opts), new Error('There are ZERO commit to relase!'))
+  t.rejects(() => cmd(opts), new Error('There are ZERO commit to release!'))
 })
 
 test('try to publish with a wrong token', t => {
@@ -171,7 +171,7 @@ test('fails to build the release', t => {
     external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
   })
 
-  t.rejects(() => cmd(opts), new Error("Something went wrong creating the relase on GitHub.\nThe 'npm publish' and 'git push' has been done!\nConsider creating a release on GitHub by yourself with this message:\n📚 PR:\n- this is a standard comment (#123)\n"))
+  t.rejects(() => cmd(opts), new Error("Something went wrong creating the release on GitHub.\nThe 'npm publish' and 'git push' has been done!\nConsider creating a release on GitHub by yourself with this message:\n📚 PR:\n- this is a standard comment (#123)\n"))
 })
 
 test('try to publish a module major', t => {
@@ -354,7 +354,7 @@ test('editor error', t => {
     }
   })
 
-  t.rejects(() => cmd(opts), new Error('Something went wrong creating the relase on GitHub.'))
+  t.rejects(() => cmd(opts), new Error('Something went wrong creating the release on GitHub.'))
 })
 
 test('publish a module from a branch that is not master', async t => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
