### PR TITLE
better logging output when releasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You need a [GitHub OAUTH Token][gh-token] with scope `repo:public_repo` to run t
 releasify publish [--path|-p <path>]             ➡ The path to the project to release. Default `pwd`
                   [--tag|-t <pattern>]           ➡ The pattern of the tag to release. Useful for multi-branch project. It is necessary to find the last tag released of that pipeline. Default `v${major version of the project}.\d+.\d+`
                   [--semver|-s <release>]        ➡ Force the release type. The value must be [major, premajor, minor, preminor, patch, prepatch, prerelease]
-                  [--verbose|-v <level>]         ➡ Print out more info. The value must be [debug, info, warn, error]. Default `warn`
+                  [--verbose|-v <level>]         ➡ Print out more info. The value must be [trace, debug, info, warn, error]. Default `warn`
                   [--remote|-r <string>]         ➡ The remote git where push the bumped version. Useful if you are releasing. Default `origin`
                   [--branch|-b <string>]         ➡ The branch you want to release. Useful when you need to release a multi-branch module. Default `master`
                   [--no-verify|-n]               ➡ Add the `--no-verify` to the commit, useful for slow test you don't need to run in case of bump
@@ -141,7 +141,7 @@ releasify draft [--path|-p <path>]        ➡ The path to the project to draft. 
                 [--from-commit <hash>]    ➡ Specify a commit hash where to start to generate the release message. Default `HEAD`
                 [--to-commit <hash>]      ➡ Specify a commit hash where to stop to generate the release message. The --tag arg will be ignored
                 [--semver|-s <release>]   ➡ Force the release type. The value must be [major, premajor, minor, preminor, patch, prepatch, prerelease]
-                [--verbose|-v <level>]    ➡ Print out more info. The value must be [debug, info, warn, error]
+                [--verbose|-v <level>]    ➡ Print out more info. The value must be [trace, debug, info, warn, error]
                 [--gh-group-by-label|-l <label>] ➡ Group the commits in the changelog message by PR's labels
                 [--help|-h]               ➡ Show this help message
 ```
@@ -170,7 +170,7 @@ The values are saved in an encrypted file, so it is human-unreadable.
 
 ```sh
 releasify config [--arg <string>]          ➡ The argument to save
-                 [--verbose|-v <level>]    ➡ Print out more info. The value must be [debug, info, warn, error]
+                 [--verbose|-v <level>]    ➡ Print out more info. The value must be [trace, debug, info, warn, error]
                  [--help|-h]               ➡ Show this help message
 ```
 

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -16,7 +16,7 @@ const ARGS_SCHEMA = {
     },
     verbose: {
       type: 'string',
-      enum: ['debug', 'info', 'warn', 'error']
+      enum: ['trace', 'debug', 'info', 'warn', 'error']
     }
   }
 }

--- a/lib/commands/draft.js
+++ b/lib/commands/draft.js
@@ -60,7 +60,7 @@ module.exports = async function (args) {
   const commitsWithoutPR = commitsPR.filter(c => c.pullRequest.id == null)
   logger.debug('There are %d commits message that contain a PR id and %d don\'t', commitsWithPR.length, commitsWithoutPR.length)
 
-  const github = GitHub({ url: pkg.repository.url })
+  const github = GitHub({ url: pkg.repository.url }, logger)
   logger.info('Getting PR labels from GitHub..')
   for (const commit of commitsWithPR) {
     try {
@@ -77,8 +77,7 @@ module.exports = async function (args) {
   // don't miss any commit
   commitsWithoutPR.forEach(_ => releaseBuilder.addLine(_.message))
 
-  const neverReleased = !toCommit
-  const release = args.semver || (neverReleased ? 'none' : releaseBuilder.suggestRelease())
+  const release = args.semver || releaseBuilder.suggestRelease()
   logger.debug('New semver to apply: %s', release)
 
   const newVersion = releaseBuilder.bump(release)

--- a/lib/commands/draft.js
+++ b/lib/commands/draft.js
@@ -17,7 +17,7 @@ const ARGS_SCHEMA = {
     toCommit: { type: 'string' },
     verbose: {
       type: 'string',
-      enum: ['debug', 'info', 'warn', 'error']
+      enum: ['trace', 'debug', 'info', 'warn', 'error']
     },
     semver: {
       type: 'string',

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -8,6 +8,7 @@ const Npm = require('../npm')
 const GitDirectory = require('../git-directory')
 const GitHub = require('../github')
 const { editMessage } = require('../editor')
+const debug = require('debug')
 
 // TODO this could be optimized with a common schema using $ref..
 const ARGS_SCHEMA = {
@@ -30,7 +31,7 @@ const ARGS_SCHEMA = {
     },
     verbose: {
       type: 'string',
-      enum: ['debug', 'info', 'warn', 'error']
+      enum: ['trace', 'debug', 'info', 'warn', 'error']
     },
     npmAccess: {
       type: 'string',
@@ -66,6 +67,10 @@ module.exports = async function (args) {
   validate(args, ARGS_SCHEMA)
 
   const logger = pino({ level: args.verbose, prettyPrint: true, base: null })
+
+  if (args.verbose === 'trace') {
+    debug.enable('simple-git,simple-git:*')
+  }
 
   const git = GitDirectory(args.path)
   const status = await git.status()

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -150,13 +150,14 @@ Consider creating a release on GitHub by yourself with this message:\n${releasin
     const github = GitHub({
       auth: args.ghToken,
       url: pkg.repository.url
-    })
+    }, logger)
 
     if (args.ghReleaseEdit) {
       logger.debug('Waiting for user to edit the release message..')
       releasing.message = await editMessage(releasing.message, 'edit-release-message.md')
     }
 
+    logger.debug('Creating release on GitHub..')
     const githubRelease = await github.createRelease({
       tag_name: `v${releasing.version}`,
       target_commitish: commited.branch,
@@ -165,16 +166,20 @@ Consider creating a release on GitHub by yourself with this message:\n${releasin
       draft: args.ghReleaseDraft,
       prerelease: args.ghReleasePrerelease
     })
-    logger.info('Created GitHub release: %s', githubRelease.data.html_url)
-
-    await git.pull(args.remote)
-    logger.debug('Pulled new tags from remote: %s', args.remote)
+    logger.info('Created GitHub release: %s', (githubRelease && githubRelease.data && githubRelease.data.html_url))
   } catch (error) {
     logger.error(error)
     const messageError = `Something went wrong creating the release on GitHub.
 The 'npm publish' and 'git push' has been done!
 Consider creating a release on GitHub by yourself with this message:\n${releasing.message}`
     throw new Error(messageError)
+  }
+
+  try {
+    await git.pull(args.remote)
+    logger.debug('Pulled new tags from remote: %s', args.remote)
+  } catch (error) {
+    logger.warn('Unable to pull the new release tag due: %s', error.message)
   }
 
   return releasing

--- a/lib/github.js
+++ b/lib/github.js
@@ -3,10 +3,19 @@
 const parseGitUrl = require('parse-github-url')
 const { Octokit } = require('@octokit/rest')
 
-module.exports = function github ({ url, auth }) {
+module.exports = function github ({ url, auth }, logger) {
   const { owner, name } = parseGitUrl(url)
 
-  const octokit = new Octokit({ auth })
+  const octokit = new Octokit({
+    auth,
+
+    log: {
+      debug: logger.trace.bind(logger),
+      info: logger.info.bind(logger),
+      warn: logger.warn.bind(logger),
+      error: logger.error.bind(logger)
+    }
+  })
   return {
     getPRLabels,
     createRelease
@@ -25,7 +34,7 @@ module.exports = function github ({ url, auth }) {
       repo: name,
       ...opts
     }
-    // https://octokit.github.io/rest.js/#api-Repos-createRelease
+    // https://octokit.github.io/rest.js/v18#api-Repos-createRelease
     return octokit.repos.createRelease(theRelease)
   }
 }

--- a/man/config
+++ b/man/config
@@ -5,7 +5,7 @@ Usage: releasify config [--arg <string>] [--verbose|-v <level>] [--help|-h]
       The argument name or alias to save
 
   -v, --verbose <level>
-      Print out more info. The value must be [debug, info, warn, error]
+      Print out more info. The value must be [trace, debug, info, warn, error]
 
   -h, --help
       Show this help message

--- a/man/draft
+++ b/man/draft
@@ -17,7 +17,7 @@ Usage: releasify draft [--path|-p <path>] [--semver|-s <release>] [--tag|-t <pat
       Force the release type. The value must be [major, premajor, minor, preminor, patch, prepatch, prerelease]
 
   -v, --verbose <level>
-      Print out more info. The value must be [debug, info, warn, error]
+      Print out more info. The value must be [trace, debug, info, warn, error]
 
   -l, --gh-group-by-label <label>
       Group the commits in the release message by PR's labels

--- a/man/publish
+++ b/man/publish
@@ -11,7 +11,7 @@ Usage: releasify publish [--path|-p <path>] [--tag|-t <pattern>] [--semver|-s <r
       Force the release type. The value must be [major, premajor, minor, preminor, patch, prepatch, prerelease]
 
   -v, --verbose <level>
-      Print out more info. The value must be [debug, info, warn, error]. Default `warn`
+      Print out more info. The value must be [trace, debug, info, warn, error]. Default `warn`
 
   -r, --remote <string>
       The remote git where push the bumped version. Useful if you are releasing. Default `origin`

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ajv": "^6.12.2",
     "commist": "^2.0.0",
     "conf": "^10.0.0",
+    "debug": "^4.3.2",
     "enquirer": "^2.3.5",
     "open-editor": "^3.0.0",
     "parse-github-url": "^1.0.2",

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -121,6 +121,29 @@ test('publish a module never released', async t => {
   })
 })
 
+test('publish a module never released and fail the pull', async t => {
+  t.plan(1)
+  const cmd = h.buildProxyCommand('../lib/commands/publish', {
+    git: { pull: { throwError: true } },
+    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+  })
+  const opts = buildOptions()
+  opts.semver = 'minor'
+  opts.verbose = 'trace'
+  opts.ghToken = '0000000000000000000000000000000000000000'
+  delete opts.tag
+
+  const out = await cmd(opts)
+  t.strictSame(out, {
+    lines: 1,
+    message: '📚 PR:\n- this is a standard comment (#123)\n',
+    name: 'fake-project',
+    oldVersion: '11.14.42',
+    release: 'minor',
+    version: '11.15.0'
+  })
+})
+
 test('try to publish a module version already released', t => {
   t.plan(1)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {


### PR DESCRIPTION
Fixes https://github.com/fastify/releasify/issues/122

This PR adds more log on the GitHub rest-client and isolates the `git.pull(args.remote)` call.

I think the error shown was caused by the `git pull` failure: this explains the created GH release.
This is not a blocking error, so I have added a warning for it.

I would suggest running the:

```
releasify config --arg verbose -v debug
```

for a better output during the releases


cc @simoneb 