### PR TITLE
remove inquirer

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -9,7 +9,7 @@ const GitDirectory = require('../git-directory')
 const GitHub = require('../github')
 const { editMessage } = require('../editor')
 const getRepositoryUrl = require('../getRepositoryUrl')
-const inquirer = require('inquirer')
+const { Input } = require('enquirer')
 const debug = require('debug')
 
 // TODO this could be optimized with a common schema using $ref..
@@ -133,11 +133,9 @@ module.exports = async function (args) {
       if (args.npmOtp) {
         logger.error(`OTP code "${args.npmOtp}" is not valid`)
       }
-      const { inputtedOtp } = await inquirer.prompt({
-        type: 'input',
-        name: 'inputtedOtp',
-        message: `OTP code is required to publish ${moduleLink} to NPM:`
-      })
+
+      const prompt = new Input({ message: `OTP code is required to publish ${moduleLink} to NPM:` })
+      const inputtedOtp = await prompt.run()
 
       await npm.publish({ tag: args.npmDistTag, access: args.npmAccess, otp: inputtedOtp })
     } else {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "conf": "^10.0.0",
     "debug": "^4.3.2",
     "enquirer": "^2.3.5",
-    "inquirer": "^8.1.5",
     "open-editor": "^3.0.0",
     "parse-github-url": "^1.0.2",
     "pino": "^7.0.1",

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -340,10 +340,10 @@ test('publish npm within npm-otp input', async t => {
     },
     external: {
       './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 2 } } }),
-      inquirer: {
-        async prompt (params) {
+      enquirer: {
+        Input: function (params) {
           t.match(params.message, /fake-project@11\.15\.0/)
-          return { inputtedOtp: '123456' }
+          return { async run () { return '123456' } }
         }
       }
     }


### PR DESCRIPTION
We use inquirer and enquirer. I think one should be enough. Did not run it locally just adapted the tests.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
