### PR TITLE
Revert "build(deps): bump simple-git from 2.48.0 to 3.0.3"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       license-check: true
       lint: true
+      auto-merge-exclude: 'simple-git'

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pino": "^7.0.1",
     "pino-pretty": "^8.0.0",
     "semver": "^7.3.2",
-    "simple-git": "^3.0.3",
+    "simple-git": "^2.37.0",
     "temp-write": "^4.0.0",
     "yargs-parser": "^13.1.2"
   },


### PR DESCRIPTION
Reverts fastify/releasify#211

causes:

```
➜  any-schema-you-like git:(master) releasify publish -n -s major -m
  simple-git:scheduler Constructed, concurrency=5 +0ms
  simple-git:task:status:1 Adding task to the queue, commands = [ 'status', '--porcelain', '-b', '-u', '--null' ] +0ms
(node:1550) [PINODEP008] PinoWarning: prettyPrint is deprecated, look at https://github.com/pinojs/pino-pretty for alternatives.
(Use `node --trace-warnings ...` to show where the warning was created)
  simple-git:scheduler Scheduling id=1 +2ms
  simple-git:scheduler Attempting id=1 +0ms
  simple-git:task:status:1 Starting task +1ms
  simple-git [GitExecutor] [SPAWN] git [ 'status', '--porcelain', '-b', '-u', '--null' ] +0ms
  simple-git:task:status:1 [SPAWN] git [ 'status', '--porcelain', '-b', '-u', '--null' ] +0ms
  simple-git:task:status:1 [SPAWN] {
  simple-git:task:status:1   cwd: '/Users/mspigolon/workspace/any-schema-you-like',
  simple-git:task:status:1   env: undefined,
  simple-git:task:status:1   windowsHide: true
  simple-git:task:status:1 } +0ms
  simple-git:task:status:1 [SPAWN] stdOut received 26 bytes +15ms
  simple-git:output:status:1 [stdOut] ## master...origin/master +0ms
  simple-git:task:status:1 [HANDLE] Preparing to handle process response exitCode=0 stdOut= +1ms
  simple-git [GitExecutor] [HANDLE] retrieving task output complete +16ms
  simple-git:task:status:1 [HANDLE] retrieving task output complete +0ms
  simple-git:task:status:1 passing response to task's parser as a utf-8 +0ms
  simple-git:scheduler Completing id= 1 +16ms
  simple-git:scheduler Schedule attempt ignored, pending=0 running=0 concurrency=5 +0ms
[] ERROR: Cannot read properties of undefined (reading 'length')
    err: {
      "type": "TypeError",
      "message": "Cannot read properties of undefined (reading 'length')",
      "stack":
          TypeError: Cannot read properties of undefined (reading 'length')
              at /Users/mspigolon/.nvm/versions/node/v18.6.0/lib/node_modules/releasify/lib/commands/publish.js:213:12
              at Array.reduce (<anonymous>)
              at inlineNotEmpty (/Users/mspigolon/.nvm/versions/node/v18.6.0/lib/node_modules/releasify/lib/commands/publish.js:210:28)
              at module.exports (/Users/mspigolon/.nvm/versions/node/v18.6.0/lib/node_modules/releasify/lib/commands/publish.js:82:43)
              at async Command.func (/Users/mspigolon/.nvm/versions/node/v18.6.0/lib/node_modules/releasify/lib/cli.js:18:7)
    }
```