### PR TITLE
fix: compare only a git status subset

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -220,5 +220,6 @@ function inlineNotEmpty (json) {
 function buildGitStatus (current) {
   return Object.keys(CLEAN_REPO).reduce((acc, key) => {
     acc[key] = current[key]
+    return acc
   }, {})
 }

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -80,7 +80,7 @@ module.exports = async function (args) {
   delete compare.current // the current branch could be named in a different way
   CLEAN_REPO.tracking = `${args.remote}/${args.branch}` // your local branch must track where you will push
   logger.debug('Complete repo status %s', inlineNotEmpty(status))
-  assert.deepStrictEqual(compare, CLEAN_REPO, 'The git repo must be clean (committed and pushed) before releasing!')
+  assert.deepStrictEqual(buildGitStatus(compare), CLEAN_REPO, 'The git repo must be clean (committed and pushed) before releasing!')
 
   logger.debug('Building draft release..')
   const releasing = await draft(args)
@@ -215,4 +215,10 @@ function inlineNotEmpty (json) {
     }
     return msg
   }, '')
+}
+
+function buildGitStatus (current) {
+  return Object.keys(CLEAN_REPO).reduce((acc, key) => {
+    acc[key] = current[key]
+  }, {})
 }


### PR DESCRIPTION
releasify v3 triggers this error on node v18.

Note the `detached` property.

This fix aims to check only the fields we are interested in

```
[1661407621817] DEBUG: Complete repo status current="master" tracking="origin/master"
ERROR: The git repo must be clean (committed and pushed) before releasing!
    err: {
      "type": "AssertionError",
      "message": "The git repo must be clean (committed and pushed) before releasing!",
      "stack":
          AssertionError [ERR_ASSERTION]: The git repo must be clean (committed and pushed) before releasing!
              at module.exports (/Users/mspigolon/.nvm/versions/node/v18.6.0/lib/node_modules/releasify/lib/commands/publish.js:83:10)
              at async Command.func (/Users/mspigolon/.nvm/versions/node/v18.6.0/lib/node_modules/releasify/lib/cli.js:18:7)
      "generatedMessage": false,
      "code": "ERR_ASSERTION",
      "actual": {
        "not_added": [],
        "conflicted": [],
        "created": [],
        "deleted": [],
        "modified": [],
        "renamed": [],
        "files": [],
        "staged": [],
        "ahead": 0,
        "behind": 0,
        "tracking": "origin/master",
        "detached": false
      },
      "expected": {
        "not_added": [],
        "conflicted": [],
        "created": [],
        "deleted": [],
        "modified": [],
        "renamed": [],
        "files": [],
        "staged": [],
        "ahead": 0,
        "behind": 0,
        "tracking": "origin/master"
      },
      "operator": "deepStrictEqual"
    }
```