### PR TITLE
feat: #255 use gh generate_release_notes when gh-release-edit not passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ releasify publish [--path|-p <path>]             ➡ The path to the project to 
                   [--silent]                     ➡ never ask for user input. Note that if 2FA is required for publishing this flag must be used with `npm-otp` flag
                   [--no-verify|-n]               ➡ Add the `--no-verify` to the commit, useful for slow test you don't need to run in case of bump
                   [--gh-token|-k <env | token>]  ➡ The GitHub OAUTH token. You can set it with an env var name or a valid token. Default env var `GITHUB_OAUTH_TOKEN`
-                  [--gh-release-edit|-e]         ➡ Open an editor to modify the release message before creating it on GitHub. Default will use github `generate_release_notes` option if argument is excluded.
+                  [--gh-release-edit|-e]         ➡ Open an editor to modify the release message before creating it on GitHub
                   [--gh-release-draft]           ➡ Create the GitHub Release as draft. Default `false`
                   [--gh-release-prerelease]      ➡ Create the GitHub Release as pre-release. Default `false`
+                  [--gh-release-body|-x]            ➡ Automatically generate body via Github. When `true` will take priority over `--gh-release-edit`. Default `false`
                   [--gh-group-by-label|-l <label>] ➡ Group the commits in the changelog message by PR's labels
                   [--npm-access|-a <string>]       ➡ It will set the --access flag of `npm publish` command. Useful for scoped modules. The value must be [public, restricted]
                   [--npm-dist-tag <string>]        ➡ It will add a npm tag to the module, like `beta` or `next`

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ releasify publish [--path|-p <path>]             ➡ The path to the project to 
                   [--silent]                     ➡ never ask for user input. Note that if 2FA is required for publishing this flag must be used with `npm-otp` flag
                   [--no-verify|-n]               ➡ Add the `--no-verify` to the commit, useful for slow test you don't need to run in case of bump
                   [--gh-token|-k <env | token>]  ➡ The GitHub OAUTH token. You can set it with an env var name or a valid token. Default env var `GITHUB_OAUTH_TOKEN`
-                  [--gh-release-edit|-e]         ➡ Open an editor to modify the release message before creating it on GitHub
+                  [--gh-release-edit|-e]         ➡ Open an editor to modify the release message before creating it on GitHub. Default will use github `generate_release_notes` option if argument is excluded.
                   [--gh-release-draft]           ➡ Create the GitHub Release as draft. Default `false`
                   [--gh-release-prerelease]      ➡ Create the GitHub Release as pre-release. Default `false`
                   [--gh-group-by-label|-l <label>] ➡ Group the commits in the changelog message by PR's labels

--- a/lib/args.js
+++ b/lib/args.js
@@ -27,7 +27,8 @@ const argsNames = {
     'silent',
     'gh-release-edit',
     'gh-release-draft',
-    'gh-release-prerelease'
+    'gh-release-prerelease',
+    'gh-release-body'
   ]
 }
 
@@ -48,6 +49,7 @@ module.exports = function parsedArgs (args) {
     'gh-release-draft': false,
     'gh-release-prerelease': false,
     'gh-release-edit': false,
+    'gh-release-body': false,
     'gh-group-by-label': []
   }, config.store)
 
@@ -64,6 +66,7 @@ module.exports = function parsedArgs (args) {
       'npm-access': ['a'],
       'gh-token': ['k'],
       'gh-release-edit': ['e'],
+      'gh-release-body': ['x'],
       'gh-group-by-label': ['l'],
       verbose: ['v'],
       semver: ['s'],
@@ -95,6 +98,7 @@ module.exports = function parsedArgs (args) {
     ghReleaseEdit: parsedArgs['gh-release-edit'],
     ghReleaseDraft: parsedArgs['gh-release-draft'],
     ghReleasePrerelease: parsedArgs['gh-release-prerelease'],
+    ghReleaseBody: parsedArgs['gh-release-body'],
     ghGroupByLabel: parsedArgs['gh-group-by-label'],
     npmAccess: parsedArgs['npm-access'],
     npmDistTag: parsedArgs['npm-dist-tag'],

--- a/lib/commands/draft.js
+++ b/lib/commands/draft.js
@@ -53,32 +53,32 @@ module.exports = async function (args) {
     toCommit = await git.getLastTagCommit(tagPattern)
     if (!toCommit) { toCommit = 'HEAD' }
   }
-  if (!args.ghReleaseBody) {
-    const commits = await git.getLogs(args.fromCommit, toCommit)
-    logger.debug('Found %d commits from %s to %s', commits.length, args.fromCommit, toCommit)
 
-    const commitsPR = commits.map(addPullRequestId)
-    const commitsWithPR = commitsPR.filter(c => c.pullRequest.id != null)
-    const commitsWithoutPR = commitsPR.filter(c => c.pullRequest.id == null)
-    logger.debug('There are %d commits message that contain a PR id and %d don\'t', commitsWithPR.length, commitsWithoutPR.length)
+  const commits = await git.getLogs(args.fromCommit, toCommit)
+  logger.debug('Found %d commits from %s to %s', commits.length, args.fromCommit, toCommit)
 
-    const github = GitHub({ url: pkg.repository.url }, logger)
-    logger.info('Getting PR labels from GitHub..')
-    for (const commit of commitsWithPR) {
-      try {
-        const response = await github.getPRLabels(commit.pullRequest.id)
-        const labels = response.data.map(_ => _.name)
-        logger.debug('\tGet PR %s labels %o', commit.pullRequest.id, labels)
-        releaseBuilder.addLine(commit.message, labels)
-      } catch (error) {
-        logger.warn(error, '\tError getting PR %s', commit.pullRequest.id)
-        releaseBuilder.addLine(commit.message, [])
-      }
+  const commitsPR = commits.map(addPullRequestId)
+
+  const commitsWithPR = commitsPR.filter(c => c.pullRequest.id != null)
+  const commitsWithoutPR = commitsPR.filter(c => c.pullRequest.id == null)
+  logger.debug('There are %d commits message that contain a PR id and %d don\'t', commitsWithPR.length, commitsWithoutPR.length)
+
+  const github = GitHub({ url: pkg.repository.url }, logger)
+  logger.info('Getting PR labels from GitHub..')
+  for (const commit of commitsWithPR) {
+    try {
+      const response = await github.getPRLabels(commit.pullRequest.id)
+      const labels = response.data.map(_ => _.name)
+      logger.debug('\tGet PR %s labels %o', commit.pullRequest.id, labels)
+      releaseBuilder.addLine(commit.message, labels)
+    } catch (error) {
+      logger.warn(error, '\tError getting PR %s', commit.pullRequest.id)
+      releaseBuilder.addLine(commit.message, [])
     }
-
-    // don't miss any commit
-    commitsWithoutPR.forEach(_ => releaseBuilder.addLine(_.message))
   }
+
+  // don't miss any commit
+  commitsWithoutPR.forEach(_ => releaseBuilder.addLine(_.message))
 
   const release = args.semver || releaseBuilder.suggestRelease()
   logger.debug('New semver to apply: %s', release)

--- a/lib/commands/draft.js
+++ b/lib/commands/draft.js
@@ -23,6 +23,7 @@ const ARGS_SCHEMA = {
       type: 'string',
       enum: ['major', 'premajor', 'minor', 'preminor', 'patch', 'prepatch', 'prerelease']
     },
+    ghReleaseBody: { type: 'boolean' },
     ghGroupByLabel: {
       type: 'array',
       items: {
@@ -40,7 +41,7 @@ module.exports = async function (args) {
   const git = GitDirectory(args.path)
 
   const pkg = git.getRepoPackage()
-  const releaseBuilder = ReleaseBuilder(pkg.name, { labels: args.ghGroupByLabel })
+  const releaseBuilder = ReleaseBuilder(pkg.name, { labels: args.ghGroupByLabel, releaseBody: args.ghReleaseBody })
   releaseBuilder.setCurrentVersion(pkg.version)
   logger.debug('Found %s version: %s', releaseBuilder.getName(), releaseBuilder.getCurrentVersion())
 
@@ -52,30 +53,32 @@ module.exports = async function (args) {
     toCommit = await git.getLastTagCommit(tagPattern)
     if (!toCommit) { toCommit = 'HEAD' }
   }
-  const commits = await git.getLogs(args.fromCommit, toCommit)
-  logger.debug('Found %d commits from %s to %s', commits.length, args.fromCommit, toCommit)
+  if (!args.ghReleaseBody) {
+    const commits = await git.getLogs(args.fromCommit, toCommit)
+    logger.debug('Found %d commits from %s to %s', commits.length, args.fromCommit, toCommit)
 
-  const commitsPR = commits.map(addPullRequestId)
-  const commitsWithPR = commitsPR.filter(c => c.pullRequest.id != null)
-  const commitsWithoutPR = commitsPR.filter(c => c.pullRequest.id == null)
-  logger.debug('There are %d commits message that contain a PR id and %d don\'t', commitsWithPR.length, commitsWithoutPR.length)
+    const commitsPR = commits.map(addPullRequestId)
+    const commitsWithPR = commitsPR.filter(c => c.pullRequest.id != null)
+    const commitsWithoutPR = commitsPR.filter(c => c.pullRequest.id == null)
+    logger.debug('There are %d commits message that contain a PR id and %d don\'t', commitsWithPR.length, commitsWithoutPR.length)
 
-  const github = GitHub({ url: pkg.repository.url }, logger)
-  logger.info('Getting PR labels from GitHub..')
-  for (const commit of commitsWithPR) {
-    try {
-      const response = await github.getPRLabels(commit.pullRequest.id)
-      const labels = response.data.map(_ => _.name)
-      logger.debug('\tGet PR %s labels %o', commit.pullRequest.id, labels)
-      releaseBuilder.addLine(commit.message, labels)
-    } catch (error) {
-      logger.warn(error, '\tError getting PR %s', commit.pullRequest.id)
-      releaseBuilder.addLine(commit.message, [])
+    const github = GitHub({ url: pkg.repository.url }, logger)
+    logger.info('Getting PR labels from GitHub..')
+    for (const commit of commitsWithPR) {
+      try {
+        const response = await github.getPRLabels(commit.pullRequest.id)
+        const labels = response.data.map(_ => _.name)
+        logger.debug('\tGet PR %s labels %o', commit.pullRequest.id, labels)
+        releaseBuilder.addLine(commit.message, labels)
+      } catch (error) {
+        logger.warn(error, '\tError getting PR %s', commit.pullRequest.id)
+        releaseBuilder.addLine(commit.message, [])
+      }
     }
-  }
 
-  // don't miss any commit
-  commitsWithoutPR.forEach(_ => releaseBuilder.addLine(_.message))
+    // don't miss any commit
+    commitsWithoutPR.forEach(_ => releaseBuilder.addLine(_.message))
+  }
 
   const release = args.semver || releaseBuilder.suggestRelease()
   logger.debug('New semver to apply: %s', release)

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -185,7 +185,8 @@ Consider creating a release on GitHub by yourself with this message:\n${releasin
       name: `v${releasing.version}`,
       body: releasing.message,
       draft: args.ghReleaseDraft,
-      prerelease: args.ghReleasePrerelease
+      prerelease: args.ghReleasePrerelease,
+      generate_release_notes: !args.ghReleaseEdit
     })
     logger.info('Created GitHub release: %s', (githubRelease && githubRelease.data && githubRelease.data.html_url))
   } catch (error) {

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -87,7 +87,7 @@ module.exports = async function (args) {
   const releasing = await draft(args)
   logger.info('Ready to release %s: %s --> %s', releasing.release, releasing.oldVersion, releasing.version)
 
-  if (!args.ghReleaseBody && releasing.lines === 0) {
+  if (releasing.lines === 0) {
     throw new Error('There are ZERO commit to release!')
   }
 

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -23,6 +23,7 @@ const ARGS_SCHEMA = {
     ghReleaseEdit: { type: 'boolean' },
     ghReleaseDraft: { type: 'boolean' },
     ghReleasePrerelease: { type: 'boolean' },
+    ghReleaseBody: { type: 'boolean' },
     path: { type: 'string' },
     tag: { type: 'string' },
     remote: { type: 'string' },
@@ -173,7 +174,7 @@ Consider creating a release on GitHub by yourself with this message:\n${releasin
       logger
     )
 
-    if (args.ghReleaseEdit) {
+    if (!args.ghReleaseBody && args.ghReleaseEdit) {
       logger.debug('Waiting for user to edit the release message..')
       releasing.message = await editMessage(releasing.message, 'edit-release-message.md')
     }
@@ -186,7 +187,7 @@ Consider creating a release on GitHub by yourself with this message:\n${releasin
       body: releasing.message,
       draft: args.ghReleaseDraft,
       prerelease: args.ghReleasePrerelease,
-      generate_release_notes: !args.ghReleaseEdit
+      generate_release_notes: args.ghReleaseBody
     })
     logger.info('Created GitHub release: %s', (githubRelease && githubRelease.data && githubRelease.data.html_url))
   } catch (error) {

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -87,7 +87,7 @@ module.exports = async function (args) {
   const releasing = await draft(args)
   logger.info('Ready to release %s: %s --> %s', releasing.release, releasing.oldVersion, releasing.version)
 
-  if (releasing.lines === 0) {
+  if (!args.ghReleaseBody && releasing.lines === 0) {
     throw new Error('There are ZERO commit to release!')
   }
 

--- a/lib/release-builder.js
+++ b/lib/release-builder.js
@@ -2,7 +2,7 @@
 
 const semver = require('semver')
 
-module.exports = function releaseBuilder (moduleName, { labels }) {
+module.exports = function releaseBuilder (moduleName, { labels, releaseBody }) {
   const groupLabels = labels
   const semverBuckets = {
     commit: []
@@ -73,6 +73,7 @@ module.exports = function releaseBuilder (moduleName, { labels }) {
   }
 
   function toString () {
+    if (releaseBody) { return null }
     if (groupLabels.length) {
       return [...groupLabels, 'commit']
         .reduce((out, label) => {

--- a/man/publish
+++ b/man/publish
@@ -32,13 +32,16 @@ Usage: releasify publish [--path|-p <path>] [--tag|-t <pattern>] [--semver|-s <r
       Group the commits in the release message by PR's labels
 
   -e, --gh-release-edit
-      Open an editor to modify the release message before creating it on GitHub. Default will use github `generate_release_notes` option if argument is excluded.
+      Open an editor to modify the release message before creating it on GitHub
 
   --gh-release-draft
       Create the GitHub Release as draft. Default `false`
 
   --gh-release-prerelease
       Create the GitHub Release as pre-release. Default `false`
+
+  --gh-release-body
+      Automatically generate body via Github. When `true` will take priority over `--gh-release-edit`. Default `false`
 
   -a, --npm-access <string>
       It will set the --access flag of `npm publish` command. Useful for scoped modules. The value must be [public, restricted]

--- a/man/publish
+++ b/man/publish
@@ -32,7 +32,7 @@ Usage: releasify publish [--path|-p <path>] [--tag|-t <pattern>] [--semver|-s <r
       Group the commits in the release message by PR's labels
 
   -e, --gh-release-edit
-      Open an editor to modify the release message before creating it on GitHub
+      Open an editor to modify the release message before creating it on GitHub. Default will use github `generate_release_notes` option if argument is excluded.
 
   --gh-release-draft
       Create the GitHub Release as draft. Default `false`

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -30,6 +30,7 @@ test('parse all args', t => {
     '--gh-release-edit', 'true',
     '--gh-release-draft', 'true',
     '--gh-release-prerelease', 'true',
+    '--gh-release-body', 'true',
     '--gh-group-by-label', 'bugfix',
     '--gh-group-by-label', 'docs'
   ]
@@ -58,6 +59,7 @@ test('parse all args', t => {
     ghReleaseEdit: true,
     ghReleaseDraft: true,
     ghReleasePrerelease: true,
+    ghReleaseBody: true,
     ghGroupByLabel: ['bugfix', 'docs']
   })
 })
@@ -89,6 +91,7 @@ test('check default values', t => {
     ghReleaseEdit: false,
     ghReleaseDraft: false,
     ghReleasePrerelease: false,
+    ghReleaseBody: false,
     ghGroupByLabel: []
   })
 })
@@ -118,6 +121,7 @@ test('parse args with = assignment', t => {
     '--gh-release-edit=true',
     '--gh-release-draft=true',
     '--gh-release-prerelease=true',
+    '--gh-release-body=true',
     '--gh-group-by-label=bugfix',
     '--gh-group-by-label=docs'
   ]
@@ -146,6 +150,7 @@ test('parse args with = assignment', t => {
     ghReleaseEdit: true,
     ghReleaseDraft: true,
     ghReleasePrerelease: true,
+    ghReleaseBody: true,
     ghGroupByLabel: ['bugfix', 'docs']
   })
 })
@@ -160,7 +165,8 @@ test('parse boolean args', t => {
     '--no-verify',
     '--gh-release-edit',
     '--gh-release-draft',
-    '--gh-release-prerelease'
+    '--gh-release-prerelease',
+    '--gh-release-body'
   ]
   const parsedArgs = parseArgs(argv)
 
@@ -171,7 +177,8 @@ test('parse boolean args', t => {
     noVerify: true,
     ghReleaseEdit: true,
     ghReleaseDraft: true,
-    ghReleasePrerelease: true
+    ghReleasePrerelease: true,
+    ghReleaseBody: true
   })
 })
 
@@ -191,6 +198,7 @@ test('parse args aliases', t => {
     '-a', 'public',
     '-k', 'MY_KEY',
     '-e',
+    '-x',
     '-l', 'bugfix',
     '-l', 'docs'
   ]
@@ -219,6 +227,7 @@ test('parse args aliases', t => {
     ghReleaseEdit: true,
     ghReleaseDraft: false,
     ghReleasePrerelease: false,
+    ghReleaseBody: true,
     ghGroupByLabel: ['bugfix', 'docs']
   })
 })

--- a/test/command-draft.test.js
+++ b/test/command-draft.test.js
@@ -19,7 +19,8 @@ function buildOptions () {
     verbose: 'error',
     fromCommit: 'HEAD',
     semver: null,
-    ghGroupByLabel: []
+    ghGroupByLabel: [],
+    ghReleaseBody: false
   }
   return Object.assign({}, options)
 }
@@ -57,6 +58,22 @@ test('draft a suggested release', async t => {
   // TODO: now the suggestedRelease is not implemented
   t.equal(build.version, '11.14.42')
   t.equal(build.oldVersion, '11.14.42')
+})
+
+test('draft a null commit message', async t => {
+  t.plan(4)
+
+  const opts = buildOptions()
+  opts.ghReleaseBody = true
+  opts.path = join(__dirname, 'fake-project/')
+  opts.semver = 'major'
+  delete opts.tag // autosense
+
+  const build = await cmd(opts)
+  t.equal(build.name, 'fake-project')
+  t.equal(build.version, '12.0.0')
+  t.equal(build.oldVersion, '11.14.42')
+  t.equal(build.message, null)
 })
 
 test('draft a range commit release message', async t => {

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -276,8 +276,8 @@ test('publish a module with github generate release notes', async t => {
 
   const out = await cmd(opts)
   t.strictSame(out, {
-    lines: 1,
-    message: '📚 PR:\n- this is a standard comment (#123)\n',
+    lines: 0,
+    message: null,
     name: 'fake-project',
     oldVersion: '11.14.42',
     release: 'minor',
@@ -316,8 +316,8 @@ test('publish a module with gh-release-body taking priority', async t => {
 
   const out = await cmd(opts)
   t.strictSame(out, {
-    lines: 1,
-    message: '📚 PR:\n- this is a standard comment (#123)\n',
+    lines: 0,
+    message: null,
     name: 'fake-project',
     oldVersion: '11.14.42',
     release: 'minor',

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -246,14 +246,15 @@ test('publish a module major', async t => {
   })
 })
 
-test('publish a module never released', async t => {
+test('publish a module with github generate release notes', async t => {
   t.plan(4)
+
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
     npm: {
       ping: { code: 0, data: 'Ping success: {}' },
       config: { code: 0, data: 'my-registry' },
       whoami: { code: 0, data: 'John Doo' },
-      show: { code: 1 } // npm return 404
+      publish: { code: 0 }
     },
     github: {
       release: {
@@ -266,10 +267,51 @@ test('publish a module never released', async t => {
     },
     external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
   })
+
   const opts = buildOptions()
   opts.semver = 'minor'
   opts.ghToken = '0000000000000000000000000000000000000000'
-  opts.ghReleaseEdit = false
+  opts.ghReleaseBody = true
+  delete opts.tag
+
+  const out = await cmd(opts)
+  t.strictSame(out, {
+    lines: 1,
+    message: '📚 PR:\n- this is a standard comment (#123)\n',
+    name: 'fake-project',
+    oldVersion: '11.14.42',
+    release: 'minor',
+    version: '11.15.0'
+  })
+})
+
+test('publish a module with gh-release-body taking priority', async t => {
+  t.plan(4)
+
+  const cmd = h.buildProxyCommand('../lib/commands/publish', {
+    npm: {
+      ping: { code: 0, data: 'Ping success: {}' },
+      config: { code: 0, data: 'my-registry' },
+      whoami: { code: 0, data: 'John Doo' },
+      publish: { code: 0 }
+    },
+    github: {
+      release: {
+        inputChecker (releaseParams) {
+          t.equal(releaseParams.tag_name, 'v11.15.0')
+          t.equal(releaseParams.name, releaseParams.tag_name)
+          t.equal(releaseParams.generate_release_notes, true)
+        }
+      }
+    },
+    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+  })
+
+  const opts = buildOptions()
+  opts.semver = 'minor'
+  opts.ghToken = '0000000000000000000000000000000000000000'
+  opts.ghReleaseEdit = true
+  opts.ghReleaseBody = true
   delete opts.tag
 
   const out = await cmd(opts)
@@ -398,7 +440,7 @@ test('publish npm within npm-otp input', async t => {
 })
 
 test('publish a module minor editing the release message', async t => {
-  t.plan(8)
+  t.plan(4)
 
   const opts = buildOptions()
   opts.semver = 'minor'
@@ -414,16 +456,6 @@ test('publish a module minor editing the release message', async t => {
       config: { code: 0, data: 'my-registry' },
       whoami: { code: 0, data: 'John Doo' },
       publish: { code: 0 }
-    },
-    github: {
-      release: {
-        inputChecker (releaseParams) {
-          t.equal(releaseParams.tag_name, 'v11.15.0')
-          t.equal(releaseParams.name, releaseParams.tag_name)
-          t.equal(releaseParams.body, 'my message')
-          t.equal(releaseParams.generate_release_notes, false)
-        }
-      }
     },
     external: {
       './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 2 } } }),

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -276,7 +276,7 @@ test('publish a module with github generate release notes', async t => {
 
   const out = await cmd(opts)
   t.strictSame(out, {
-    lines: 0,
+    lines: 1,
     message: null,
     name: 'fake-project',
     oldVersion: '11.14.42',
@@ -316,7 +316,7 @@ test('publish a module with gh-release-body taking priority', async t => {
 
   const out = await cmd(opts)
   t.strictSame(out, {
-    lines: 0,
+    lines: 1,
     message: null,
     name: 'fake-project',
     oldVersion: '11.14.42',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
