### PR TITLE
fix: setting message to undefined when release-body set

### DIFF
--- a/lib/release-builder.js
+++ b/lib/release-builder.js
@@ -73,7 +73,7 @@ module.exports = function releaseBuilder (moduleName, { labels, releaseBody }) {
   }
 
   function toString () {
-    if (releaseBody) { return null }
+    if (releaseBody) { return undefined }
     if (groupLabels.length) {
       return [...groupLabels, 'commit']
         .reduce((out, label) => {

--- a/test/command-draft.test.js
+++ b/test/command-draft.test.js
@@ -60,7 +60,7 @@ test('draft a suggested release', async t => {
   t.equal(build.oldVersion, '11.14.42')
 })
 
-test('draft a null commit message', async t => {
+test('draft a undefined commit message', async t => {
   t.plan(4)
 
   const opts = buildOptions()
@@ -73,7 +73,7 @@ test('draft a null commit message', async t => {
   t.equal(build.name, 'fake-project')
   t.equal(build.version, '12.0.0')
   t.equal(build.oldVersion, '11.14.42')
-  t.equal(build.message, null)
+  t.equal(build.message, undefined)
 })
 
 test('draft a range commit release message', async t => {

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -277,7 +277,7 @@ test('publish a module with github generate release notes', async t => {
   const out = await cmd(opts)
   t.strictSame(out, {
     lines: 1,
-    message: null,
+    message: undefined,
     name: 'fake-project',
     oldVersion: '11.14.42',
     release: 'minor',
@@ -317,7 +317,7 @@ test('publish a module with gh-release-body taking priority', async t => {
   const out = await cmd(opts)
   t.strictSame(out, {
     lines: 1,
-    message: null,
+    message: undefined,
     name: 'fake-project',
     oldVersion: '11.14.42',
     release: 'minor',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
