### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const assert = require('assert').strict
+const assert = require('node:assert').strict
 const pino = require('pino')
 const { validate } = require('../validation')
 const draft = require('./draft')

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const fs = require('fs')
-const { promisify } = require('util')
+const fs = require('node:fs')
+const { promisify } = require('node:util')
 const open = require('open-editor')
 const tempWrite = require('temp-write')
-const { spawn } = require('child_process')
+const { spawn } = require('node:child_process')
 
 const readFile = promisify(fs.readFile)
 

--- a/lib/git-directory.js
+++ b/lib/git-directory.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const { join } = require('path')
-const { readFileSync } = require('fs')
-const { promisify } = require('util')
+const { join } = require('node:path')
+const { readFileSync } = require('node:fs')
+const { promisify } = require('node:util')
 const SimpleGit = require('simple-git')
 
 module.exports = function gitDirectory (path) {

--- a/lib/man.js
+++ b/lib/man.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const path = require('path')
-const { readFileSync } = require('fs')
+const path = require('node:path')
+const { readFileSync } = require('node:fs')
 
 module.exports.needToShowHelp = function (file, opts) {
   if (opts.help || opts._.length > 0) {

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { spawn } = require('child_process')
+const { spawn } = require('node:child_process')
 
 function runSpawn (cwd, cmd, args) {
   return new Promise((resolve, reject) => {

--- a/test/command-config.test.js
+++ b/test/command-config.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const h = require('./helper')
-const fs = require('fs')
+const fs = require('node:fs')
 
 const cmd = h.buildProxyCommand('../lib/commands/config')
 const LocalConf = require('../lib/local-conf')

--- a/test/command-draft.test.js
+++ b/test/command-draft.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const t = require('tap')
-const { join } = require('path')
+const { join } = require('node:path')
 const h = require('./helper')
 
 const cmd = h.buildProxyCommand('../lib/commands/draft', {

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const { EventEmitter } = require('events')
+const { EventEmitter } = require('node:events')
 const t = require('tap')
-const { join } = require('path')
+const { join } = require('node:path')
 const proxyquire = require('proxyquire')
 const h = require('./helper')
 

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -467,14 +467,14 @@ test('publish a module minor editing the release message', async t => {
             return { arguments: [] }
           }
         },
-        child_process: {
+        'node:child_process': {
           spawn: () => {
             const e = new EventEmitter()
             setImmediate(() => { e.emit('exit', 0) })
             return e
           }
         },
-        fs: {
+        'node:fs': {
           readFile (tmpFile, opts, cb) {
             t.equal(tmpFile, fakeFile)
             cb(null, 'my message')
@@ -524,14 +524,14 @@ test('editor error', t => {
             return { arguments: [] }
           }
         },
-        child_process: {
+        'node:child_process': {
           spawn: () => {
             const e = new EventEmitter()
             setImmediate(() => { e.emit('exit', 1) })
             return e
           }
         },
-        fs: {
+        'node:fs': {
           readFile () { t.fail('The file has not been edited') }
         }
       })

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const { spawn } = require('child_process')
-const fs = require('fs')
-const path = require('path')
+const { spawn } = require('node:child_process')
+const fs = require('node:fs')
+const path = require('node:path')
 const proxyquire = require('proxyquire')
 
 const factorySimpleGit = require('./proxy/simple-git-proxy')

--- a/test/helper.js
+++ b/test/helper.js
@@ -30,7 +30,7 @@ function buildProxyCommand (commandPath, opts = {}) {
       '@octokit/rest': factoryOctokit(opts.github)
     }),
     '../npm': proxyquire('../lib/npm', {
-      child_process: factoryNpm(opts.npm)
+      'node:child_process': factoryNpm(opts.npm)
     }),
     ...opts.external
   })


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
