### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "yargs-parser": "^21.1.0"
   },
   "devDependencies": {
+    "eslint": "^9.17.0",
     "neostandard": "^0.11.9",
     "proxyquire": "^2.1.3",
     "tap": "^16.0.0"


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.