### PR TITLE
fix: skip git lebel get

### DIFF
--- a/lib/commands/draft.js
+++ b/lib/commands/draft.js
@@ -41,7 +41,7 @@ module.exports = async function (args) {
   const git = GitDirectory(args.path)
 
   const pkg = git.getRepoPackage()
-  const releaseBuilder = ReleaseBuilder(pkg.name, { labels: args.ghGroupByLabel, releaseBody: args.ghReleaseBody })
+  const releaseBuilder = ReleaseBuilder(pkg.name, { labels: args.ghGroupByLabel })
   releaseBuilder.setCurrentVersion(pkg.version)
   logger.debug('Found %s version: %s', releaseBuilder.getName(), releaseBuilder.getCurrentVersion())
 
@@ -63,17 +63,24 @@ module.exports = async function (args) {
   const commitsWithoutPR = commitsPR.filter(c => c.pullRequest.id == null)
   logger.debug('There are %d commits message that contain a PR id and %d don\'t', commitsWithPR.length, commitsWithoutPR.length)
 
-  const github = GitHub({ url: pkg.repository.url }, logger)
-  logger.info('Getting PR labels from GitHub..')
-  for (const commit of commitsWithPR) {
-    try {
-      const response = await github.getPRLabels(commit.pullRequest.id)
-      const labels = response.data.map(_ => _.name)
-      logger.debug('\tGet PR %s labels %o', commit.pullRequest.id, labels)
-      releaseBuilder.addLine(commit.message, labels)
-    } catch (error) {
-      logger.warn(error, '\tError getting PR %s', commit.pullRequest.id)
+  if (args.ghReleaseBody) {
+    logger.debug('Skipping getting PR labels from GitHub as ghReleaseBody is set to true')
+    commits.forEach(commit => {
       releaseBuilder.addLine(commit.message, [])
+    })
+  } else {
+    const github = GitHub({ url: pkg.repository.url }, logger)
+    logger.info('Getting PR labels from GitHub..')
+    for (const commit of commitsWithPR) {
+      try {
+        const response = await github.getPRLabels(commit.pullRequest.id)
+        const labels = response.data.map(_ => _.name)
+        logger.debug('\tGet PR %s labels %o', commit.pullRequest.id, labels)
+        releaseBuilder.addLine(commit.message, labels)
+      } catch (error) {
+        logger.warn(error, '\tError getting PR %s', commit.pullRequest.id)
+        releaseBuilder.addLine(commit.message, [])
+      }
     }
   }
 

--- a/lib/release-builder.js
+++ b/lib/release-builder.js
@@ -2,7 +2,7 @@
 
 const semver = require('semver')
 
-module.exports = function releaseBuilder (moduleName, { labels, releaseBody }) {
+module.exports = function releaseBuilder (moduleName, { labels }) {
   const groupLabels = labels
   const semverBuckets = {
     commit: []
@@ -73,7 +73,6 @@ module.exports = function releaseBuilder (moduleName, { labels, releaseBody }) {
   }
 
   function toString () {
-    if (releaseBody) { return undefined }
     if (groupLabels.length) {
       return [...groupLabels, 'commit']
         .reduce((out, label) => {

--- a/test/command-draft.test.js
+++ b/test/command-draft.test.js
@@ -58,22 +58,6 @@ test('draft a suggested release', async t => {
   t.assert.deepStrictEqual(build.oldVersion, '11.14.42')
 })
 
-test('draft a undefined commit message', async t => {
-  t.plan(4)
-
-  const opts = buildOptions()
-  opts.ghReleaseBody = true
-  opts.path = join(__dirname, 'fake-project/')
-  opts.semver = 'major'
-  delete opts.tag // autosense
-
-  const build = await cmd(opts)
-  t.assert.deepStrictEqual(build.name, 'fake-project')
-  t.assert.deepStrictEqual(build.version, '12.0.0')
-  t.assert.deepStrictEqual(build.oldVersion, '11.14.42')
-  t.assert.deepStrictEqual(build.message, undefined)
-})
-
 test('draft a range commit release message', async t => {
   t.plan(1)
 
@@ -303,5 +287,29 @@ test('group changelog order', async t => {
 - five this is a typescript pr (#5)
 
 
+`)
+})
+
+test('draft a release without collecting labels', async t => {
+  t.plan(1)
+
+  const cmd = h.buildProxyCommand('../lib/commands/draft', {
+    git: {
+      tag: { history: 5 },
+    },
+  })
+  const opts = buildOptions()
+  opts.path = join(__dirname, 'fake-project/')
+  opts.ghReleaseBody = true
+  delete opts.tag // autosense
+  delete opts.semver // auto-calculate
+
+  const build = await cmd(opts)
+  t.assert.deepStrictEqual(build.message, `📚 PR:
+- this is a standard comment (#123)
+- this is a standard comment (#123)
+- this is a standard comment (#123)
+- this is a standard comment (#123)
+- this is a standard comment (#123)
 `)
 })

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -281,7 +281,7 @@ test('publish a module with github generate release notes', async t => {
   const out = await cmd(opts)
   t.assert.deepStrictEqual(out, {
     lines: 1,
-    message: undefined,
+    message: '📚 PR:\n- this is a standard comment (#123)\n',
     name: 'fake-project',
     oldVersion: '11.14.42',
     release: 'minor',
@@ -321,7 +321,7 @@ test('publish a module with gh-release-body taking priority', async t => {
   const out = await cmd(opts)
   t.assert.deepStrictEqual(out, {
     lines: 1,
-    message: undefined,
+    message: '📚 PR:\n- this is a standard comment (#123)\n',
     name: 'fake-project',
     oldVersion: '11.14.42',
     release: 'minor',


### PR DESCRIPTION
When running:

```
releasify publish -s minor -n --gh-release-body -b main
```

The draft implementation reads every commit labels, even tho it is useless since the `--gh-release-body` has been set.
This cause many rate limit issues while releasing many commits (like the fastify main repo)

This fix skips the github label retrival step