### PR TITLE
fix: release message

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -184,7 +184,7 @@ Consider creating a release on GitHub by yourself with this message:\n${releasin
       tag_name: `v${releasing.version}`,
       target_commitish: commited.branch,
       name: `v${releasing.version}`,
-      body: releasing.message,
+      body: args.ghReleaseBody ? undefined : releasing.message,
       draft: args.ghReleaseDraft,
       prerelease: args.ghReleasePrerelease,
       generate_release_notes: args.ghReleaseBody

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -305,6 +305,7 @@ test('publish a module with gh-release-body taking priority', async t => {
           t.assert.deepStrictEqual(releaseParams.tag_name, 'v11.15.0')
           t.assert.deepStrictEqual(releaseParams.name, releaseParams.tag_name)
           t.assert.deepStrictEqual(releaseParams.generate_release_notes, true)
+          t.assert.equal(releaseParams.body, undefined)
         }
       }
     },

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -290,7 +290,7 @@ test('publish a module with github generate release notes', async t => {
 })
 
 test('publish a module with gh-release-body taking priority', async t => {
-  t.plan(4)
+  t.plan(5)
 
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
     npm: {


### PR DESCRIPTION
As titled:

if we set the body AND the other parameter, we get both:

<img width="1780" height="1414" alt="image" src="https://github.com/user-attachments/assets/9a889522-1887-448d-8bc6-c3835b050346" />
