### PR TITLE
feat: add --npm-browser-auth flag for WebAuthn/Passkey publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ releasify publish [--path|-p <path>]             ➡ The path to the project to 
                   [--npm-access|-a <string>]       ➡ It will set the --access flag of `npm publish` command. Useful for scoped modules. The value must be [public, restricted]
                   [--npm-dist-tag <string>]        ➡ It will add an npm tag to the module, like `beta` or `next`
                   [--npm-otp <code>]               ➡ It will provide the otp code to the npm publish. Use this only for CI. For publishing from your machine, omit this argument and you will be asked to enter OTP code just before the npm publish command gets executed.
+                  [--npm-browser-auth]             ➡ It will use npm's web-based auth (Passkeys / hardware security keys / WebAuthn) instead of a 6-digit OTP. Cannot be combined with `--npm-otp`
                   [--major|-m]                     ➡ It will unlock the release of a major release
                   [--help|-h]                      ➡ Show this help message
 ```
@@ -85,6 +86,13 @@ The following example shows how to release a minor version of `your-module` to N
 export MY_ENV_OAUTH_KEY 0000000000000000000000000000000000000000
 cd /your-module
 releasify publish -v debug -s minor -k MY_ENV_OAUTH_KEY -e --npm-otp 123456
+```
+---
+
+This example releases using npm's web-based Passkey / WebAuthn flow instead of an OTP code. A confirmation URL is printed to the terminal and `releasify` waits until it's approved in the browser:
+
+```sh
+releasify publish -v debug -s minor -k MY_ENV_OAUTH_KEY -e --npm-browser-auth
 ```
 ---
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -24,6 +24,7 @@ const optionsConfig = {
   'npm-access': { type: 'string', short: 'a' },
   'npm-dist-tag': { type: 'string' },
   'npm-otp': { type: 'string' },
+  'npm-browser-auth': { type: 'boolean' },
   'gh-token': { type: 'string', short: 'k' },
   arg: { type: 'string' },
   'gh-group-by-label': { type: 'string', short: 'l', multiple: true }
@@ -47,7 +48,8 @@ module.exports = function parsedArgs (args) {
     'gh-release-prerelease': false,
     'gh-release-edit': false,
     'gh-release-body': false,
-    'gh-group-by-label': []
+    'gh-group-by-label': [],
+    'npm-browser-auth': false
   }, config.store)
 
   const { values, positionals } = parseArgs({
@@ -108,6 +110,7 @@ module.exports = function parsedArgs (args) {
     npmAccess: values['npm-access'],
     npmDistTag: values['npm-dist-tag'],
     npmOtp: values['npm-otp'],
+    npmBrowserAuth: values['npm-browser-auth'],
     tag: values.tag,
     verbose: values.verbose,
     semver: values.semver,

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -44,6 +44,7 @@ const ARGS_SCHEMA = {
       type: 'string',
       pattern: '^[^v0-9][\\w]{1,12}'
     },
+    npmBrowserAuth: { type: 'boolean' },
     semver: {
       type: 'string',
       enum: ['major', 'premajor', 'minor', 'preminor', 'patch', 'prepatch', 'prerelease']
@@ -68,6 +69,10 @@ const CLEAN_REPO = {
 // TODO refactor to make optionals step (publish / push / release)
 module.exports = async function (args) {
   validate(args, ARGS_SCHEMA)
+
+  if (args.npmOtp && args.npmBrowserAuth) {
+    throw new Error('You can not use --npm-otp and --npm-browser-auth together, choose one 2FA method')
+  }
 
   const logger = pino({ level: args.verbose, base: null, transport: { target: 'pino-pretty' } })
 
@@ -127,10 +132,16 @@ module.exports = async function (args) {
   // ! DANGER ZONE: from this point if some error occurs we must explain to user what to do to fix
 
   // ? publish at the end??
+  if (args.npmBrowserAuth) {
+    logger.info('Waiting for browser/Passkey confirmation to publish %s..', moduleLink)
+  }
+
   try {
-    await npm.publish({ tag: args.npmDistTag, access: args.npmAccess, otp: args.npmOtp })
+    await npm.publish({ tag: args.npmDistTag, access: args.npmAccess, otp: args.npmOtp, browserAuth: args.npmBrowserAuth })
   } catch (err) {
-    if ((err.message.includes('npm ERR! code EOTP') || err.message.includes('one-time password')) && !args.silent) {
+    // the browser-based flow handles its own retries inside npm itself,
+    // so there is no OTP-retry-prompt fallback for it
+    if (!args.npmBrowserAuth && (err.message.includes('npm ERR! code EOTP') || err.message.includes('one-time password')) && !args.silent) {
       if (args.npmOtp) {
         logger.error(`OTP code "${args.npmOtp}" is not valid`)
       }

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -2,7 +2,7 @@
 
 const { spawn } = require('node:child_process')
 
-function runSpawn (cwd, cmd, args) {
+function runSpawn (cwd, cmd, args, { echo = false } = {}) {
   return new Promise((resolve, reject) => {
     const cli = spawn(cmd, args, { cwd, env: process.env, shell: true })
     cli.stdout.setEncoding('utf8')
@@ -10,8 +10,16 @@ function runSpawn (cwd, cmd, args) {
 
     let stdout = ''
     let stderr = ''
-    cli.stdout.on('data', (data) => { stdout += data })
-    cli.stderr.on('data', (data) => { stderr += data })
+    cli.stdout.on('data', (data) => {
+      stdout += data
+      // when waiting for a browser/WebAuthn login, npm prints the
+      // one-time URL on stdout: it must be shown live to the user
+      if (echo) process.stdout.write(data)
+    })
+    cli.stderr.on('data', (data) => {
+      stderr += data
+      if (echo) process.stderr.write(data)
+    })
     cli.on('close', (code, signal) => {
       if (code === 0) {
         return resolve(stdout.trim())
@@ -40,7 +48,7 @@ module.exports = function npmWrapper (cwd) {
       // 💩 https://github.com/npm/npm/issues/17327
       return runSpawn(cwd, 'npm', ['--no-git-tag-version', '--allow-same-version', 'version', version])
     },
-    publish ({ tag, access, otp }) {
+    publish ({ tag, access, otp, browserAuth }) {
       const args = ['publish']
       if (tag) {
         args.push('--tag')
@@ -52,12 +60,19 @@ module.exports = function npmWrapper (cwd) {
         args.push(access)
       }
 
-      if (otp) {
+      if (browserAuth) {
+        // delegates 2FA to npm's native web-based flow (Passkeys / hardware
+        // security keys / WebAuthn), which opens a URL the user confirms
+        // in the browser instead of typing a 6-digit OTP
+        args.push('--auth-type=web')
+      } else if (otp) {
         args.push('--otp')
         args.push(otp)
       }
 
-      return runSpawn(cwd, 'npm', args)
+      // in browser-auth mode npm prints the confirmation URL on stdout and
+      // blocks waiting for the user: that output must be streamed live
+      return runSpawn(cwd, 'npm', args, { echo: !!browserAuth })
     }
   }
 }

--- a/man/publish
+++ b/man/publish
@@ -1,4 +1,4 @@
-Usage: releasify publish [--path|-p <path>] [--tag|-t <pattern>] [--semver|-s <release>] [--verbose|-v <level>] [--remote|-r <string>] [--branch|-b <string>] [--no-verify|-n] [--gh-token|-k <env name var | token>] [--gh-release-edit|-e] [--gh-release-draft] [--gh-release-prerelease] [--npm-access|-a <string>] [--npm-dist-tag <string>] [--npm-otp <code>] [--major|-m] [--help|-h]
+Usage: releasify publish [--path|-p <path>] [--tag|-t <pattern>] [--semver|-s <release>] [--verbose|-v <level>] [--remote|-r <string>] [--branch|-b <string>] [--no-verify|-n] [--gh-token|-k <env name var | token>] [--gh-release-edit|-e] [--gh-release-draft] [--gh-release-prerelease] [--npm-access|-a <string>] [--npm-dist-tag <string>] [--npm-otp <code>] [--npm-browser-auth] [--major|-m] [--help|-h]
   publish to npm a new version of a module and create the GitHub Release with the changelogs
 
   -p, --path <path>
@@ -51,6 +51,10 @@ Usage: releasify publish [--path|-p <path>] [--tag|-t <pattern>] [--semver|-s <r
 
   --npm-otp <code>
       It will provide the otp code to the npm publish. For publishing from your machine, omit this argument-you will be asked to enter OTP code just before the npm publish command gets executed.
+
+  --npm-browser-auth
+      It will use npm's web-based authentication (Passkeys / WebAuthn) instead of a 6-digit OTP. A confirmation URL will be printed and releasify will wait until you approve it in the browser. Cannot be used together with `--npm-otp`.
+
   -m, --major
       It will unlock the release of a major release
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "test": "c8 --100 node --test"
+    "test": "c8 --100 node --test --test-concurrency=1"
   },
   "dependencies": {
     "@octokit/rest": "^22.0.1",

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -6,7 +6,7 @@ const parseArgs = require('../lib/args')
 const proxyquire = require('proxyquire')
 
 test('parse all args', t => {
-  t.plan(24)
+  t.plan(25)
 
   const argv = [
     '--arg', 'arg',
@@ -60,10 +60,19 @@ test('parse all args', t => {
   t.assert.deepStrictEqual(parsedArgs.ghReleasePrerelease, true)
   t.assert.deepStrictEqual(parsedArgs.ghReleaseBody, true)
   t.assert.deepStrictEqual(parsedArgs.ghGroupByLabel, ['bugfix', 'docs'])
+  t.assert.deepStrictEqual(parsedArgs.npmBrowserAuth, false)
+})
+
+test('parse npm-browser-auth flag', t => {
+  t.plan(1)
+
+  const parsedArgs = parseArgs(['--npm-browser-auth'])
+
+  t.assert.deepStrictEqual(parsedArgs.npmBrowserAuth, true)
 })
 
 test('check default values', t => {
-  t.plan(24)
+  t.plan(25)
   const parsedArgs = parseArgs([])
 
   t.assert.deepStrictEqual(parsedArgs._, [])
@@ -90,6 +99,7 @@ test('check default values', t => {
   t.assert.deepStrictEqual(parsedArgs.ghReleasePrerelease, false)
   t.assert.deepStrictEqual(parsedArgs.ghReleaseBody, false)
   t.assert.deepStrictEqual(parsedArgs.ghGroupByLabel, [])
+  t.assert.deepStrictEqual(parsedArgs.npmBrowserAuth, false)
 })
 
 test('parse args with = assignment', t => {
@@ -139,6 +149,7 @@ test('parse args with = assignment', t => {
     toCommit: 'commitTo',
     noVerify: false,
     npmOtp: '123123',
+    npmBrowserAuth: false,
     silent: false,
     npmAccess: 'public',
     npmDistTag: 'next',

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -444,6 +444,64 @@ test('publish npm within npm-otp input', async t => {
   })
 })
 
+test('publish npm with npm-browser-auth', async t => {
+  t.plan(2)
+
+  const opts = buildOptions()
+  opts.semver = 'minor'
+  opts.ghToken = '0000000000000000000000000000000000000000'
+  opts.npmAccess = 'public'
+  opts.npmBrowserAuth = true
+  opts.noVerify = true
+  opts.silent = false
+  delete opts.tag
+
+  const cmd = h.buildProxyCommand('../lib/commands/publish', {
+    npm: {
+      ping: { code: 0, data: 'Ping success: {}' },
+      config: { code: 0, data: 'my-registry' },
+      whoami: { code: 0, data: 'John Doo' },
+      publish: {
+        code: 0,
+        data: 'Open this URL in your browser to authenticate:\nhttps://www.npmjs.com/auth/cli/abc123\n',
+        errorData: 'npm notice waiting for browser authentication...\n',
+        inputChecker (publishArgs) {
+          t.assert.deepStrictEqual(publishArgs, [
+            '--access',
+            opts.npmAccess,
+            '--auth-type=web'
+          ])
+        }
+      }
+    },
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 2 } }
+      })
+    }
+  })
+
+  const out = await cmd(opts)
+  t.assert.deepStrictEqual(out.version, '11.15.0')
+})
+
+test('reject when npm-otp and npm-browser-auth are used together', async t => {
+  t.plan(1)
+
+  const opts = buildOptions()
+  opts.semver = 'minor'
+  opts.ghToken = '0000000000000000000000000000000000000000'
+  opts.npmOtp = '123456'
+  opts.npmBrowserAuth = true
+  delete opts.tag
+
+  const cmd = h.buildProxyCommand('../lib/commands/publish', {
+    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 2 } } }) }
+  })
+
+  await t.assert.rejects(() => cmd(opts), new Error('You can not use --npm-otp and --npm-browser-auth together, choose one 2FA method'))
+})
+
 test('publish a module minor editing the release message', async t => {
   t.plan(4)
 

--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -1,15 +1,32 @@
 'use strict'
 
 const { EventEmitter } = require('node:events')
-const { test } = require('node:test')
+const { test, beforeEach, afterEach } = require('node:test')
 const { join } = require('node:path')
 const proxyquire = require('proxyquire')
 const h = require('./helper')
 
+let originalExitListeners = []
+
+beforeEach(() => {
+  // Store the active exit listeners before the test begins execution
+  originalExitListeners = process.listeners('exit')
+})
+
+afterEach(() => {
+  // Purge any orphan process exit listeners registered by proxyquire sub-dependencies during the test execution
+  const currentListeners = process.listeners('exit')
+  for (const listener of currentListeners) {
+    if (!originalExitListeners.includes(listener)) {
+      process.removeListener('exit', listener)
+    }
+  }
+})
+
 const cmd = h.buildProxyCommand('../lib/commands/publish', {
   git: { tag: { history: 5 } },
-  github: { }, // default OK
-  npm: { } // default OK
+  github: {}, // default OK
+  npm: {} // default OK
 })
 
 function buildOptions () {
@@ -29,13 +46,23 @@ function buildOptions () {
   return Object.assign({}, options)
 }
 
-test('mandatory options', t => {
+test('mandatory options', (t) => {
   t.plan(2)
-  t.assert.rejects(() => cmd({}), new Error(" must have required property 'path',  must have required property 'verbose',  must have required property 'major',  must have required property 'remote',  must have required property 'branch',  must have required property 'semver',  must have required property 'ghToken'"))
-  t.assert.rejects(() => cmd(buildOptions()), new Error('.tag must be string, .ghToken must NOT have fewer than 40 characters, .semver must be string, .semver must be equal to one of the allowed values'))
+  t.assert.rejects(
+    () => cmd({}),
+    new Error(
+      " must have required property 'path',  must have required property 'verbose',  must have required property 'major',  must have required property 'remote',  must have required property 'branch',  must have required property 'semver',  must have required property 'ghToken'"
+    )
+  )
+  t.assert.rejects(
+    () => cmd(buildOptions()),
+    new Error(
+      '.tag must be string, .ghToken must NOT have fewer than 40 characters, .semver must be string, .semver must be equal to one of the allowed values'
+    )
+  )
 })
 
-test('try to publish a repo not sync', async t => {
+test('try to publish a repo not sync', async (t) => {
   t.plan(1)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
     git: { status: { dirty: true } }
@@ -49,48 +76,75 @@ test('try to publish a repo not sync', async t => {
     await cmd(opts)
     t.assert.fail('should not succeed')
   } catch (error) {
-    t.assert.ok(error.message.includes('The git repo must be clean (committed and pushed) before releasing!'))
+    t.assert.ok(
+      error.message.includes(
+        'The git repo must be clean (committed and pushed) before releasing!'
+      )
+    )
   }
 })
 
-test('try to publish 0 new commits', t => {
+test('try to publish 0 new commits', (t) => {
   t.plan(1)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 0 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 0 } }
+      })
+    }
   })
   const opts = buildOptions()
   opts.semver = 'patch'
   opts.ghToken = '0000000000000000000000000000000000000000'
   delete opts.tag
-  t.assert.rejects(() => cmd(opts), new Error('There are ZERO commit to release!'))
+  t.assert.rejects(
+    () => cmd(opts),
+    new Error('There are ZERO commit to release!')
+  )
 })
 
-test('try to publish with a wrong token', t => {
+test('try to publish with a wrong token', (t) => {
   t.plan(1)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
   const opts = buildOptions()
   opts.semver = 'patch'
   opts.ghToken = 'NOT-EXISTING-ENV-KEY'
   delete opts.tag
-  t.assert.rejects(() => cmd(opts), new Error('.ghToken must NOT have fewer than 40 characters'))
+  t.assert.rejects(
+    () => cmd(opts),
+    new Error('.ghToken must NOT have fewer than 40 characters')
+  )
 })
 
-test('npm ping failed', t => {
+test('npm ping failed', (t) => {
   t.plan(1)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
     npm: { ping: { code: 1 } },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
   const opts = buildOptions()
   opts.semver = 'minor'
   opts.ghToken = '0000000000000000000000000000000000000000'
   delete opts.tag
-  t.assert.rejects(() => cmd(opts), new Error('npm ping returned code 1 and signal undefined\nSTDOUT: \nSTDERR: '))
+  t.assert.rejects(
+    () => cmd(opts),
+    new Error(
+      'npm ping returned code 1 and signal undefined\nSTDOUT: \nSTDERR: '
+    )
+  )
 })
 
-test('publish a module never released', async t => {
+test('publish a module never released', async (t) => {
   t.plan(3)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
     npm: {
@@ -107,7 +161,11 @@ test('publish a module never released', async t => {
         }
       }
     },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
   const opts = buildOptions()
   opts.semver = 'minor'
@@ -125,11 +183,15 @@ test('publish a module never released', async t => {
   })
 })
 
-test('publish a module never released and fail the pull', async t => {
+test('publish a module never released and fail the pull', async (t) => {
   t.plan(1)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
     git: { pull: { throwError: true } },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
   const opts = buildOptions()
   opts.semver = 'minor'
@@ -148,7 +210,7 @@ test('publish a module never released and fail the pull', async t => {
   })
 })
 
-test('try to publish a module version already released', t => {
+test('try to publish a module version already released', (t) => {
   t.plan(1)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
     npm: {
@@ -157,16 +219,25 @@ test('try to publish a module version already released', t => {
       whoami: { code: 0, data: 'John Doo' },
       show: { code: 0, data: '11.15.0' }
     },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
   const opts = buildOptions()
   opts.semver = 'minor'
   opts.ghToken = '0000000000000000000000000000000000000000'
   delete opts.tag
-  t.assert.rejects(() => cmd(opts), new Error('The module fake-project@11.15.0 is already published in the registry my-registry'))
+  t.assert.rejects(
+    () => cmd(opts),
+    new Error(
+      'The module fake-project@11.15.0 is already published in the registry my-registry'
+    )
+  )
 })
 
-test('fails to push the release', t => {
+test('fails to push the release', (t) => {
   t.plan(1)
 
   const opts = buildOptions()
@@ -178,13 +249,22 @@ test('fails to push the release', t => {
     npm: { ping: { code: 0, data: 'Ping success: {}' } },
     git: { commit: { throwError: true } },
     github: { release: { throwError: true } },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
 
-  t.assert.rejects(() => cmd(opts), new Error("Something went wrong pushing the package.json to git.\nThe 'npm publish' has been done! Check your 'git status' and if necessary run 'npm unpublish fake-project@11.14.43'.\nConsider creating a release on GitHub by yourself with this message:\n📚 PR:\n- this is a standard comment (#123)\n"))
+  t.assert.rejects(
+    () => cmd(opts),
+    new Error(
+      "Something went wrong pushing the package.json to git.\nThe 'npm publish' has been done! Check your 'git status' and if necessary run 'npm unpublish fake-project@11.14.43'.\nConsider creating a release on GitHub by yourself with this message:\n📚 PR:\n- this is a standard comment (#123)\n"
+    )
+  )
 })
 
-test('fails to build the release', t => {
+test('fails to build the release', (t) => {
   t.plan(1)
 
   const opts = buildOptions()
@@ -195,25 +275,41 @@ test('fails to build the release', t => {
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
     npm: { ping: { code: 0, data: 'Ping success: {}' } },
     github: { release: { throwError: true } },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
 
-  t.assert.rejects(() => cmd(opts), new Error("Something went wrong creating the release on GitHub.\nThe 'npm publish' and 'git push' has been done!\nConsider creating a release on GitHub by yourself with this message:\n📚 PR:\n- this is a standard comment (#123)\n"))
+  t.assert.rejects(
+    () => cmd(opts),
+    new Error(
+      "Something went wrong creating the release on GitHub.\nThe 'npm publish' and 'git push' has been done!\nConsider creating a release on GitHub by yourself with this message:\n📚 PR:\n- this is a standard comment (#123)\n"
+    )
+  )
 })
 
-test('try to publish a module major', t => {
+test('try to publish a module major', (t) => {
   t.plan(1)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
   const opts = buildOptions()
   opts.semver = 'major'
   opts.ghToken = '0000000000000000000000000000000000000000'
   delete opts.tag
-  t.assert.rejects(() => cmd(opts), new Error('You can not release a major version without --major flag'))
+  t.assert.rejects(
+    () => cmd(opts),
+    new Error('You can not release a major version without --major flag')
+  )
 })
 
-test('publish a module major', async t => {
+test('publish a module major', async (t) => {
   t.plan(2)
 
   const opts = buildOptions()
@@ -232,17 +328,27 @@ test('publish a module major', async t => {
       publish: {
         code: 0,
         inputChecker (publishArgs) {
-          t.assert.deepStrictEqual(publishArgs, ['--tag', opts.npmDistTag, '--access', opts.npmAccess])
+          t.assert.deepStrictEqual(publishArgs, [
+            '--tag',
+            opts.npmDistTag,
+            '--access',
+            opts.npmAccess
+          ])
         }
       }
     },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 3 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 3 } }
+      })
+    }
   })
 
   const out = await cmd(opts)
   t.assert.deepStrictEqual(out, {
     lines: 3,
-    message: '📚 PR:\n- this is a standard comment (#123)\n- this is a standard comment (#123)\n- this is a standard comment (#123)\n',
+    message:
+      '📚 PR:\n- this is a standard comment (#123)\n- this is a standard comment (#123)\n- this is a standard comment (#123)\n',
     name: 'fake-project',
     oldVersion: '11.14.42',
     release: 'major',
@@ -250,7 +356,7 @@ test('publish a module major', async t => {
   })
 })
 
-test('publish a module with github generate release notes', async t => {
+test('publish a module with github generate release notes', async (t) => {
   t.plan(4)
 
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
@@ -269,7 +375,11 @@ test('publish a module with github generate release notes', async t => {
         }
       }
     },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
 
   const opts = buildOptions()
@@ -289,7 +399,7 @@ test('publish a module with github generate release notes', async t => {
   })
 })
 
-test('publish a module with gh-release-body taking priority', async t => {
+test('publish a module with gh-release-body taking priority', async (t) => {
   t.plan(5)
 
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
@@ -309,7 +419,11 @@ test('publish a module with gh-release-body taking priority', async t => {
         }
       }
     },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
 
   const opts = buildOptions()
@@ -330,7 +444,7 @@ test('publish a module with gh-release-body taking priority', async t => {
   })
 })
 
-test('publish a module minor with no-verify', async t => {
+test('publish a module minor with no-verify', async (t) => {
   t.plan(1)
 
   const opts = buildOptions()
@@ -347,13 +461,18 @@ test('publish a module minor with no-verify', async t => {
       whoami: { code: 0, data: 'John Doo' },
       publish: { code: 0 }
     },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 2 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 2 } }
+      })
+    }
   })
 
   const out = await cmd(opts)
   t.assert.deepStrictEqual(out, {
     lines: 2,
-    message: '📚 PR:\n- this is a standard comment (#123)\n- this is a standard comment (#123)\n',
+    message:
+      '📚 PR:\n- this is a standard comment (#123)\n- this is a standard comment (#123)\n',
     name: 'fake-project',
     oldVersion: '11.14.42',
     release: 'minor',
@@ -361,7 +480,7 @@ test('publish a module minor with no-verify', async t => {
   })
 })
 
-test('publish npm error', async t => {
+test('publish npm error', async (t) => {
   t.plan(2)
 
   const opts = buildOptions()
@@ -377,9 +496,18 @@ test('publish npm error', async t => {
       ping: { code: 0, data: 'Ping success: {}' },
       config: { code: 0, data: 'my-registry' },
       whoami: { code: 0, data: 'John Doo' },
-      publish: { code: 1, signal: 'foo', data: 'publishing...', errorData: 'npm OTP required' }
+      publish: {
+        code: 1,
+        signal: 'foo',
+        data: 'publishing...',
+        errorData: 'npm OTP required'
+      }
     },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 2 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 2 } }
+      })
+    }
   })
 
   try {
@@ -387,13 +515,16 @@ test('publish npm error', async t => {
     t.fail('should not succeed')
   } catch (error) {
     t.assert.ok(error)
-    t.assert.deepStrictEqual(error.message, `npm publish,--access,public returned code 1 and signal foo
+    t.assert.deepStrictEqual(
+      error.message,
+      `npm publish,--access,public returned code 1 and signal foo
 STDOUT: publishing...
-STDERR: npm OTP required`)
+STDERR: npm OTP required`
+    )
   }
 })
 
-test('publish npm within npm-otp input', async t => {
+test('publish npm within npm-otp input', async (t) => {
   t.plan(3)
 
   const opts = buildOptions()
@@ -412,22 +543,38 @@ test('publish npm within npm-otp input', async t => {
       whoami: { code: 0, data: 'John Doo' },
       publish: [
         // first run fail
-        { code: 1, signal: 'foo', data: 'publishing...', errorData: 'npm ERR! code EOTP' },
+        {
+          code: 1,
+          signal: 'foo',
+          data: 'publishing...',
+          errorData: 'npm ERR! code EOTP'
+        },
         // second run succeed
         {
           code: 0,
           inputChecker (publishArgs) {
-            t.assert.deepStrictEqual(publishArgs, ['--access', opts.npmAccess, '--otp', '123456'])
+            t.assert.deepStrictEqual(publishArgs, [
+              '--access',
+              opts.npmAccess,
+              '--otp',
+              '123456'
+            ])
           }
         }
       ]
     },
     external: {
-      './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 2 } } }),
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 2 } }
+      }),
       enquirer: {
         Input: function (params) {
           t.assert.match(params.message, /fake-project@11\.15\.0/)
-          return { async run () { return '123456' } }
+          return {
+            async run () {
+              return '123456'
+            }
+          }
         }
       }
     }
@@ -436,7 +583,8 @@ test('publish npm within npm-otp input', async t => {
   const out = await cmd(opts)
   t.assert.deepStrictEqual(out, {
     lines: 2,
-    message: '📚 PR:\n- this is a standard comment (#123)\n- this is a standard comment (#123)\n',
+    message:
+      '📚 PR:\n- this is a standard comment (#123)\n- this is a standard comment (#123)\n',
     name: 'fake-project',
     oldVersion: '11.14.42',
     release: 'minor',
@@ -444,7 +592,7 @@ test('publish npm within npm-otp input', async t => {
   })
 })
 
-test('publish npm with npm-browser-auth', async t => {
+test('publish npm with npm-browser-auth', async (t) => {
   t.plan(2)
 
   const opts = buildOptions()
@@ -485,7 +633,7 @@ test('publish npm with npm-browser-auth', async t => {
   t.assert.deepStrictEqual(out.version, '11.15.0')
 })
 
-test('reject when npm-otp and npm-browser-auth are used together', async t => {
+test('reject when npm-otp and npm-browser-auth are used together', async (t) => {
   t.plan(1)
 
   const opts = buildOptions()
@@ -496,13 +644,22 @@ test('reject when npm-otp and npm-browser-auth are used together', async t => {
   delete opts.tag
 
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 2 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 2 } }
+      })
+    }
   })
 
-  await t.assert.rejects(() => cmd(opts), new Error('You can not use --npm-otp and --npm-browser-auth together, choose one 2FA method'))
+  await t.assert.rejects(
+    () => cmd(opts),
+    new Error(
+      'You can not use --npm-otp and --npm-browser-auth together, choose one 2FA method'
+    )
+  )
 })
 
-test('publish a module minor editing the release message', async t => {
+test('publish a module minor editing the release message', async (t) => {
   t.plan(4)
 
   const opts = buildOptions()
@@ -521,7 +678,9 @@ test('publish a module minor editing the release message', async t => {
       publish: { code: 0 }
     },
     external: {
-      './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 2 } } }),
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 2 } }
+      }),
       '../editor': proxyquire('../lib/editor', {
         'temp-write': async (message, filename) => fakeFile,
         'open-editor': {
@@ -533,7 +692,9 @@ test('publish a module minor editing the release message', async t => {
         'node:child_process': {
           spawn: () => {
             const e = new EventEmitter()
-            setImmediate(() => { e.emit('exit', 0) })
+            setImmediate(() => {
+              e.emit('exit', 0)
+            })
             return e
           }
         },
@@ -542,7 +703,9 @@ test('publish a module minor editing the release message', async t => {
             t.assert.deepStrictEqual(tmpFile, fakeFile)
             cb(null, 'my message')
           },
-          unlink (tmpFile) { t.assert.deepStrictEqual(tmpFile, fakeFile) }
+          unlink (tmpFile) {
+            t.assert.deepStrictEqual(tmpFile, fakeFile)
+          }
         }
       })
     }
@@ -559,7 +722,7 @@ test('publish a module minor editing the release message', async t => {
   })
 })
 
-test('editor error', async t => {
+test('editor error', async (t) => {
   t.plan(2)
 
   const opts = buildOptions()
@@ -578,7 +741,9 @@ test('editor error', async t => {
       publish: { code: 0 }
     },
     external: {
-      './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 2 } } }),
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 2 } }
+      }),
       '../editor': proxyquire('../lib/editor', {
         'temp-write': async (message, filename) => fakeFile,
         'open-editor': {
@@ -590,12 +755,16 @@ test('editor error', async t => {
         'node:child_process': {
           spawn: () => {
             const e = new EventEmitter()
-            setImmediate(() => { e.emit('exit', 1) })
+            setImmediate(() => {
+              e.emit('exit', 1)
+            })
             return e
           }
         },
         'node:fs': {
-          readFile () { t.fail('The file has not been edited') }
+          readFile () {
+            t.fail('The file has not been edited')
+          }
         }
       })
     }
@@ -605,11 +774,15 @@ test('editor error', async t => {
     await cmd(opts)
     t.assert.fail('should not succeed')
   } catch (error) {
-    t.assert.ok(error.message.includes, 'Something went wrong creating the release on GitHub.')
+    t.assert.ok(
+      error.message.includes(
+        'Something went wrong creating the release on GitHub.'
+      )
+    )
   }
 })
 
-test('publish a module from a branch that is not main', async t => {
+test('publish a module from a branch that is not main', async (t) => {
   t.plan(2)
 
   const opts = buildOptions()
@@ -635,7 +808,11 @@ test('publish a module from a branch that is not main', async t => {
         }
       }
     },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
 
   const out = await cmd(opts)


### PR DESCRIPTION
Proposal:

- Adds a `--npm-browser-auth` flag as alternative to `--npm-otp` for 2FA during `releasify publish`, using npm's native web-based auth flow (`--auth-type=web`) which supports Passkeys and hardware security keys.

- see issue:  https://github.com/fastify/releasify/issues/353

Usage:

```sh
releasify publish --npm-browser-auth
```

Notes:
- No new dependencies, it just forwards `--auth-type=web` to `npm publish` and streams the confirmation URL live to the terminal.
- `--npm-otp` and `--npm-browser-auth` are mutually exclusive.
- Tests added