### PR TITLE
test: clean up process exit listeners after each test

### DIFF
--- a/test/command-publish.test.js
+++ b/test/command-publish.test.js
@@ -1,15 +1,32 @@
 'use strict'
 
 const { EventEmitter } = require('node:events')
-const { test } = require('node:test')
+const { test, beforeEach, afterEach } = require('node:test')
 const { join } = require('node:path')
 const proxyquire = require('proxyquire')
 const h = require('./helper')
 
+let originalExitListeners = []
+
+beforeEach(() => {
+  // Store the active exit listeners before the test begins execution
+  originalExitListeners = process.listeners('exit')
+})
+
+afterEach(() => {
+  // Purge any orphan process exit listeners registered by proxyquire sub-dependencies during the test execution
+  const currentListeners = process.listeners('exit')
+  for (const listener of currentListeners) {
+    if (!originalExitListeners.includes(listener)) {
+      process.removeListener('exit', listener)
+    }
+  }
+})
+
 const cmd = h.buildProxyCommand('../lib/commands/publish', {
   git: { tag: { history: 5 } },
-  github: { }, // default OK
-  npm: { } // default OK
+  github: {}, // default OK
+  npm: {} // default OK
 })
 
 function buildOptions () {
@@ -29,13 +46,23 @@ function buildOptions () {
   return Object.assign({}, options)
 }
 
-test('mandatory options', t => {
+test('mandatory options', (t) => {
   t.plan(2)
-  t.assert.rejects(() => cmd({}), new Error(" must have required property 'path',  must have required property 'verbose',  must have required property 'major',  must have required property 'remote',  must have required property 'branch',  must have required property 'semver',  must have required property 'ghToken'"))
-  t.assert.rejects(() => cmd(buildOptions()), new Error('.tag must be string, .ghToken must NOT have fewer than 40 characters, .semver must be string, .semver must be equal to one of the allowed values'))
+  t.assert.rejects(
+    () => cmd({}),
+    new Error(
+      " must have required property 'path',  must have required property 'verbose',  must have required property 'major',  must have required property 'remote',  must have required property 'branch',  must have required property 'semver',  must have required property 'ghToken'"
+    )
+  )
+  t.assert.rejects(
+    () => cmd(buildOptions()),
+    new Error(
+      '.tag must be string, .ghToken must NOT have fewer than 40 characters, .semver must be string, .semver must be equal to one of the allowed values'
+    )
+  )
 })
 
-test('try to publish a repo not sync', async t => {
+test('try to publish a repo not sync', async (t) => {
   t.plan(1)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
     git: { status: { dirty: true } }
@@ -49,48 +76,75 @@ test('try to publish a repo not sync', async t => {
     await cmd(opts)
     t.assert.fail('should not succeed')
   } catch (error) {
-    t.assert.ok(error.message.includes('The git repo must be clean (committed and pushed) before releasing!'))
+    t.assert.ok(
+      error.message.includes(
+        'The git repo must be clean (committed and pushed) before releasing!'
+      )
+    )
   }
 })
 
-test('try to publish 0 new commits', t => {
+test('try to publish 0 new commits', (t) => {
   t.plan(1)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 0 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 0 } }
+      })
+    }
   })
   const opts = buildOptions()
   opts.semver = 'patch'
   opts.ghToken = '0000000000000000000000000000000000000000'
   delete opts.tag
-  t.assert.rejects(() => cmd(opts), new Error('There are ZERO commit to release!'))
+  t.assert.rejects(
+    () => cmd(opts),
+    new Error('There are ZERO commit to release!')
+  )
 })
 
-test('try to publish with a wrong token', t => {
+test('try to publish with a wrong token', (t) => {
   t.plan(1)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
   const opts = buildOptions()
   opts.semver = 'patch'
   opts.ghToken = 'NOT-EXISTING-ENV-KEY'
   delete opts.tag
-  t.assert.rejects(() => cmd(opts), new Error('.ghToken must NOT have fewer than 40 characters'))
+  t.assert.rejects(
+    () => cmd(opts),
+    new Error('.ghToken must NOT have fewer than 40 characters')
+  )
 })
 
-test('npm ping failed', t => {
+test('npm ping failed', (t) => {
   t.plan(1)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
     npm: { ping: { code: 1 } },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
   const opts = buildOptions()
   opts.semver = 'minor'
   opts.ghToken = '0000000000000000000000000000000000000000'
   delete opts.tag
-  t.assert.rejects(() => cmd(opts), new Error('npm ping returned code 1 and signal undefined\nSTDOUT: \nSTDERR: '))
+  t.assert.rejects(
+    () => cmd(opts),
+    new Error(
+      'npm ping returned code 1 and signal undefined\nSTDOUT: \nSTDERR: '
+    )
+  )
 })
 
-test('publish a module never released', async t => {
+test('publish a module never released', async (t) => {
   t.plan(3)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
     npm: {
@@ -107,7 +161,11 @@ test('publish a module never released', async t => {
         }
       }
     },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
   const opts = buildOptions()
   opts.semver = 'minor'
@@ -125,11 +183,15 @@ test('publish a module never released', async t => {
   })
 })
 
-test('publish a module never released and fail the pull', async t => {
+test('publish a module never released and fail the pull', async (t) => {
   t.plan(1)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
     git: { pull: { throwError: true } },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
   const opts = buildOptions()
   opts.semver = 'minor'
@@ -148,7 +210,7 @@ test('publish a module never released and fail the pull', async t => {
   })
 })
 
-test('try to publish a module version already released', t => {
+test('try to publish a module version already released', (t) => {
   t.plan(1)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
     npm: {
@@ -157,16 +219,25 @@ test('try to publish a module version already released', t => {
       whoami: { code: 0, data: 'John Doo' },
       show: { code: 0, data: '11.15.0' }
     },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
   const opts = buildOptions()
   opts.semver = 'minor'
   opts.ghToken = '0000000000000000000000000000000000000000'
   delete opts.tag
-  t.assert.rejects(() => cmd(opts), new Error('The module fake-project@11.15.0 is already published in the registry my-registry'))
+  t.assert.rejects(
+    () => cmd(opts),
+    new Error(
+      'The module fake-project@11.15.0 is already published in the registry my-registry'
+    )
+  )
 })
 
-test('fails to push the release', t => {
+test('fails to push the release', (t) => {
   t.plan(1)
 
   const opts = buildOptions()
@@ -178,13 +249,22 @@ test('fails to push the release', t => {
     npm: { ping: { code: 0, data: 'Ping success: {}' } },
     git: { commit: { throwError: true } },
     github: { release: { throwError: true } },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
 
-  t.assert.rejects(() => cmd(opts), new Error("Something went wrong pushing the package.json to git.\nThe 'npm publish' has been done! Check your 'git status' and if necessary run 'npm unpublish fake-project@11.14.43'.\nConsider creating a release on GitHub by yourself with this message:\n📚 PR:\n- this is a standard comment (#123)\n"))
+  t.assert.rejects(
+    () => cmd(opts),
+    new Error(
+      "Something went wrong pushing the package.json to git.\nThe 'npm publish' has been done! Check your 'git status' and if necessary run 'npm unpublish fake-project@11.14.43'.\nConsider creating a release on GitHub by yourself with this message:\n📚 PR:\n- this is a standard comment (#123)\n"
+    )
+  )
 })
 
-test('fails to build the release', t => {
+test('fails to build the release', (t) => {
   t.plan(1)
 
   const opts = buildOptions()
@@ -195,25 +275,41 @@ test('fails to build the release', t => {
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
     npm: { ping: { code: 0, data: 'Ping success: {}' } },
     github: { release: { throwError: true } },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
 
-  t.assert.rejects(() => cmd(opts), new Error("Something went wrong creating the release on GitHub.\nThe 'npm publish' and 'git push' has been done!\nConsider creating a release on GitHub by yourself with this message:\n📚 PR:\n- this is a standard comment (#123)\n"))
+  t.assert.rejects(
+    () => cmd(opts),
+    new Error(
+      "Something went wrong creating the release on GitHub.\nThe 'npm publish' and 'git push' has been done!\nConsider creating a release on GitHub by yourself with this message:\n📚 PR:\n- this is a standard comment (#123)\n"
+    )
+  )
 })
 
-test('try to publish a module major', t => {
+test('try to publish a module major', (t) => {
   t.plan(1)
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
   const opts = buildOptions()
   opts.semver = 'major'
   opts.ghToken = '0000000000000000000000000000000000000000'
   delete opts.tag
-  t.assert.rejects(() => cmd(opts), new Error('You can not release a major version without --major flag'))
+  t.assert.rejects(
+    () => cmd(opts),
+    new Error('You can not release a major version without --major flag')
+  )
 })
 
-test('publish a module major', async t => {
+test('publish a module major', async (t) => {
   t.plan(2)
 
   const opts = buildOptions()
@@ -232,17 +328,27 @@ test('publish a module major', async t => {
       publish: {
         code: 0,
         inputChecker (publishArgs) {
-          t.assert.deepStrictEqual(publishArgs, ['--tag', opts.npmDistTag, '--access', opts.npmAccess])
+          t.assert.deepStrictEqual(publishArgs, [
+            '--tag',
+            opts.npmDistTag,
+            '--access',
+            opts.npmAccess
+          ])
         }
       }
     },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 3 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 3 } }
+      })
+    }
   })
 
   const out = await cmd(opts)
   t.assert.deepStrictEqual(out, {
     lines: 3,
-    message: '📚 PR:\n- this is a standard comment (#123)\n- this is a standard comment (#123)\n- this is a standard comment (#123)\n',
+    message:
+      '📚 PR:\n- this is a standard comment (#123)\n- this is a standard comment (#123)\n- this is a standard comment (#123)\n',
     name: 'fake-project',
     oldVersion: '11.14.42',
     release: 'major',
@@ -250,7 +356,7 @@ test('publish a module major', async t => {
   })
 })
 
-test('publish a module with github generate release notes', async t => {
+test('publish a module with github generate release notes', async (t) => {
   t.plan(4)
 
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
@@ -269,7 +375,11 @@ test('publish a module with github generate release notes', async t => {
         }
       }
     },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
 
   const opts = buildOptions()
@@ -289,7 +399,7 @@ test('publish a module with github generate release notes', async t => {
   })
 })
 
-test('publish a module with gh-release-body taking priority', async t => {
+test('publish a module with gh-release-body taking priority', async (t) => {
   t.plan(5)
 
   const cmd = h.buildProxyCommand('../lib/commands/publish', {
@@ -309,7 +419,11 @@ test('publish a module with gh-release-body taking priority', async t => {
         }
       }
     },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
 
   const opts = buildOptions()
@@ -330,7 +444,7 @@ test('publish a module with gh-release-body taking priority', async t => {
   })
 })
 
-test('publish a module minor with no-verify', async t => {
+test('publish a module minor with no-verify', async (t) => {
   t.plan(1)
 
   const opts = buildOptions()
@@ -347,13 +461,18 @@ test('publish a module minor with no-verify', async t => {
       whoami: { code: 0, data: 'John Doo' },
       publish: { code: 0 }
     },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 2 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 2 } }
+      })
+    }
   })
 
   const out = await cmd(opts)
   t.assert.deepStrictEqual(out, {
     lines: 2,
-    message: '📚 PR:\n- this is a standard comment (#123)\n- this is a standard comment (#123)\n',
+    message:
+      '📚 PR:\n- this is a standard comment (#123)\n- this is a standard comment (#123)\n',
     name: 'fake-project',
     oldVersion: '11.14.42',
     release: 'minor',
@@ -361,7 +480,7 @@ test('publish a module minor with no-verify', async t => {
   })
 })
 
-test('publish npm error', async t => {
+test('publish npm error', async (t) => {
   t.plan(2)
 
   const opts = buildOptions()
@@ -377,9 +496,18 @@ test('publish npm error', async t => {
       ping: { code: 0, data: 'Ping success: {}' },
       config: { code: 0, data: 'my-registry' },
       whoami: { code: 0, data: 'John Doo' },
-      publish: { code: 1, signal: 'foo', data: 'publishing...', errorData: 'npm OTP required' }
+      publish: {
+        code: 1,
+        signal: 'foo',
+        data: 'publishing...',
+        errorData: 'npm OTP required'
+      }
     },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 2 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 2 } }
+      })
+    }
   })
 
   try {
@@ -387,13 +515,16 @@ test('publish npm error', async t => {
     t.fail('should not succeed')
   } catch (error) {
     t.assert.ok(error)
-    t.assert.deepStrictEqual(error.message, `npm publish,--access,public returned code 1 and signal foo
+    t.assert.deepStrictEqual(
+      error.message,
+      `npm publish,--access,public returned code 1 and signal foo
 STDOUT: publishing...
-STDERR: npm OTP required`)
+STDERR: npm OTP required`
+    )
   }
 })
 
-test('publish npm within npm-otp input', async t => {
+test('publish npm within npm-otp input', async (t) => {
   t.plan(3)
 
   const opts = buildOptions()
@@ -412,22 +543,38 @@ test('publish npm within npm-otp input', async t => {
       whoami: { code: 0, data: 'John Doo' },
       publish: [
         // first run fail
-        { code: 1, signal: 'foo', data: 'publishing...', errorData: 'npm ERR! code EOTP' },
+        {
+          code: 1,
+          signal: 'foo',
+          data: 'publishing...',
+          errorData: 'npm ERR! code EOTP'
+        },
         // second run succeed
         {
           code: 0,
           inputChecker (publishArgs) {
-            t.assert.deepStrictEqual(publishArgs, ['--access', opts.npmAccess, '--otp', '123456'])
+            t.assert.deepStrictEqual(publishArgs, [
+              '--access',
+              opts.npmAccess,
+              '--otp',
+              '123456'
+            ])
           }
         }
       ]
     },
     external: {
-      './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 2 } } }),
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 2 } }
+      }),
       enquirer: {
         Input: function (params) {
           t.assert.match(params.message, /fake-project@11\.15\.0/)
-          return { async run () { return '123456' } }
+          return {
+            async run () {
+              return '123456'
+            }
+          }
         }
       }
     }
@@ -436,7 +583,8 @@ test('publish npm within npm-otp input', async t => {
   const out = await cmd(opts)
   t.assert.deepStrictEqual(out, {
     lines: 2,
-    message: '📚 PR:\n- this is a standard comment (#123)\n- this is a standard comment (#123)\n',
+    message:
+      '📚 PR:\n- this is a standard comment (#123)\n- this is a standard comment (#123)\n',
     name: 'fake-project',
     oldVersion: '11.14.42',
     release: 'minor',
@@ -444,7 +592,7 @@ test('publish npm within npm-otp input', async t => {
   })
 })
 
-test('publish a module minor editing the release message', async t => {
+test('publish a module minor editing the release message', async (t) => {
   t.plan(4)
 
   const opts = buildOptions()
@@ -463,7 +611,9 @@ test('publish a module minor editing the release message', async t => {
       publish: { code: 0 }
     },
     external: {
-      './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 2 } } }),
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 2 } }
+      }),
       '../editor': proxyquire('../lib/editor', {
         'temp-write': async (message, filename) => fakeFile,
         'open-editor': {
@@ -475,7 +625,9 @@ test('publish a module minor editing the release message', async t => {
         'node:child_process': {
           spawn: () => {
             const e = new EventEmitter()
-            setImmediate(() => { e.emit('exit', 0) })
+            setImmediate(() => {
+              e.emit('exit', 0)
+            })
             return e
           }
         },
@@ -484,7 +636,9 @@ test('publish a module minor editing the release message', async t => {
             t.assert.deepStrictEqual(tmpFile, fakeFile)
             cb(null, 'my message')
           },
-          unlink (tmpFile) { t.assert.deepStrictEqual(tmpFile, fakeFile) }
+          unlink (tmpFile) {
+            t.assert.deepStrictEqual(tmpFile, fakeFile)
+          }
         }
       })
     }
@@ -501,7 +655,7 @@ test('publish a module minor editing the release message', async t => {
   })
 })
 
-test('editor error', async t => {
+test('editor error', async (t) => {
   t.plan(2)
 
   const opts = buildOptions()
@@ -520,7 +674,9 @@ test('editor error', async t => {
       publish: { code: 0 }
     },
     external: {
-      './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 2 } } }),
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 2 } }
+      }),
       '../editor': proxyquire('../lib/editor', {
         'temp-write': async (message, filename) => fakeFile,
         'open-editor': {
@@ -532,12 +688,16 @@ test('editor error', async t => {
         'node:child_process': {
           spawn: () => {
             const e = new EventEmitter()
-            setImmediate(() => { e.emit('exit', 1) })
+            setImmediate(() => {
+              e.emit('exit', 1)
+            })
             return e
           }
         },
         'node:fs': {
-          readFile () { t.fail('The file has not been edited') }
+          readFile () {
+            t.fail('The file has not been edited')
+          }
         }
       })
     }
@@ -547,11 +707,15 @@ test('editor error', async t => {
     await cmd(opts)
     t.assert.fail('should not succeed')
   } catch (error) {
-    t.assert.ok(error.message.includes, 'Something went wrong creating the release on GitHub.')
+    t.assert.ok(
+      error.message.includes(
+        'Something went wrong creating the release on GitHub.'
+      )
+    )
   }
 })
 
-test('publish a module from a branch that is not main', async t => {
+test('publish a module from a branch that is not main', async (t) => {
   t.plan(2)
 
   const opts = buildOptions()
@@ -577,7 +741,11 @@ test('publish a module from a branch that is not main', async t => {
         }
       }
     },
-    external: { './draft': h.buildProxyCommand('../lib/commands/draft', { git: { tag: { history: 1 } } }) }
+    external: {
+      './draft': h.buildProxyCommand('../lib/commands/draft', {
+        git: { tag: { history: 1 } }
+      })
+    }
   })
 
   const out = await cmd(opts)


### PR DESCRIPTION
Proposal:

- Refactored `test/command-publish.test.js` to properly manage and sanitize process `exit` listeners. 

Changes:
- Added a `beforeEach` hook to store the state of active `process.listeners('exit')` before each test execution.
- Added an `afterEach` hook to purge any orphan process exit listeners registered by `proxyquire` sub-dependencies during the test run.

Why is this needed?
- Some sub-dependencies mocked via `proxyquire` were registering persistent `exit` listeners on the main process without removing them. This could leak memory and pollute the Node.js process environment, potentially disrupting proper process signaling, child process management, or Inter-Process Communication (IPC) boundaries during test orchestration in strict CI pipelines. ( see error here: https://github.com/fastify/releasify/actions/runs/28734462005/job/85212333752#step:5:228)

This PR should resolve this error CI ( in Nodejs v24.18.0 ):
```
✖ test/command-publish.test.js (1863.675396ms)
  Error: Unable to deserialize cloned data due to invalid or unsupported version.
      at #processRawBuffer (node:internal/test_runner/runner:469:20)
      at FileTest.parseMessage (node:internal/test_runner/runner:376:29)
      at Socket.<anonymous> (node:internal/test_runner/runner:524:15)
      at Socket.emit (node:events:509:28)
      at addChunk (node:internal/streams/readable:563:12)
      at readableAddChunkPushByteMode (node:internal/streams/readable:514:3)
      at Readable.push (node:internal/streams/readable:394:5)
      at Pipe.onStreamRead (node:internal/stream_base_commons:189:23)

```