### PR TITLE
fix: inherit stdio so npm --auth-type=web can wait for browser confirmation

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -4,22 +4,23 @@ const { spawn } = require('node:child_process')
 
 function runSpawn (cwd, cmd, args, { echo = false } = {}) {
   return new Promise((resolve, reject) => {
-    const cli = spawn(cmd, args, { cwd, env: process.env, shell: true })
-    cli.stdout.setEncoding('utf8')
-    cli.stderr.setEncoding('utf8')
+    // browser/WebAuthn auth needs a real TTY to poll for confirmation:
+    // inherit stdio so npm sees the actual terminal instead of a pipe
+    const stdio = echo ? 'inherit' : undefined
+    const cli = spawn(cmd, args, { cwd, env: process.env, shell: true, stdio })
 
     let stdout = ''
     let stderr = ''
-    cli.stdout.on('data', (data) => {
-      stdout += data
-      // when waiting for a browser/WebAuthn login, npm prints the
-      // one-time URL on stdout: it must be shown live to the user
-      if (echo) process.stdout.write(data)
-    })
-    cli.stderr.on('data', (data) => {
-      stderr += data
-      if (echo) process.stderr.write(data)
-    })
+
+    // with stdio: 'inherit', cli.stdout/stderr are null (output goes
+    // straight to the terminal), so only attach listeners when piped
+    if (!echo) {
+      cli.stdout.setEncoding('utf8')
+      cli.stderr.setEncoding('utf8')
+      cli.stdout.on('data', (data) => { stdout += data })
+      cli.stderr.on('data', (data) => { stderr += data })
+    }
+
     cli.on('close', (code, signal) => {
       if (code === 0) {
         return resolve(stdout.trim())


### PR DESCRIPTION
Proposal:

`releasify publish --npm-browser-auth` fails immediately with `EOTP` when there's no cached npm publish session:
```
npm error code EOTP
npm error This operation requires a one-time password.
npm error Open this URL in your browser to authenticate:
npm error   https://www.npmjs.com/auth/cli/***
```
npm's web-based auth flow (`--auth-type=web`) needs a real TTY to print the confirmation URL and poll until the user approves it in the browser. Since `runSpawn` didn't set `stdio`, the child process `stdout/stderr` were pipes rather than the actual terminal, so npm couldn't detect an interactive session and aborted right away instead of waiting.

The bug only surfaced once any previously cached npm auth session expired, which is why it could look intermittent.
Inherit stdio only when `browserAuth` is used, so npm sees the real terminal and can wait for confirmation. All other commands (`whoami`, `show`, `config`, `version`, `publish` without browser auth) are unaffected, they still use piped stdio as before.

